### PR TITLE
full ICCCM 2.0 WM_S%d selection compliance

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -314,6 +314,17 @@ void DiscardKeyEvents(XEvent *event, Window w)
 /** Process a selection clear event. */
 char HandleSelectionClear(const XSelectionClearEvent *event)
 {
+   char *name;
+   
+   if ((name = XGetAtomName(display, event->selection))) {
+      if (strncmp(name, "WM_S", 4) == 0) {
+	 /* lost WM selection - must exit */
+	 XFree(name);
+	 shouldExit = 1;
+	 return 1;
+      }
+      XFree(name);
+   }
    return HandleDockSelectionClear(event);
 }
 


### PR DESCRIPTION
- ICCCM 2.0 requires window managers to take ownership of the
  WM_S%d MANAGER selection where %d is the screen number, waiting
  for any previous owner to exit and then sending a MANAGER client
  message to the root window identifying the selection
- Also, when another window manager take the selected (a Selection
  Clear event is received for WM_S%d) the window manager cleared
  must exit.
- This commit provides JWM compliance to ICCCM 2.0 in this respect.
- Tested.
