### PR TITLE
get rid of issue #115

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1245,6 +1245,11 @@ void ReparentClient(ClientNode *np, char notOwner)
       | ButtonMotionMask
       | KeyPressMask
       | KeyReleaseMask;
+   /* Make sure client doesn't muck with these. */
+   attrMask |= CWBackingStore;
+   attr.backing_store = NotUseful;
+   attrMask |= CWWinGravity;
+   attr.win_gravity = NorthWestGravity;
    JXChangeWindowAttributes(display, np->window, attrMask, &attr);
    JXSetWindowBorderWidth(display, np->window, 0);
 


### PR DESCRIPTION
 when reparenting client window:
- sets backing store to NotUseful
- sets win gravity to NorthWestGravity
  
  in case client did something stupid with these values.
