### PR TITLE
Add install-strip option.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,4 +1,3 @@
-
 CC = @CC@
 CFLAGS = @CFLAGS@
 CPPFLAGS = @CPPFLAGS@
@@ -22,6 +21,10 @@ EXE = jwm
 all: $(EXE)
 
 install: all
+	install -d $(BINDIR)
+	install $(EXE) $(BINDIR)/$(EXE)
+
+install-strip: all
 	install -d $(BINDIR)
 	install $(EXE) $(BINDIR)/$(EXE)
 	strip $(BINDIR)/$(EXE)


### PR DESCRIPTION
I'd like to add this option because not all people want to strip the symbols by default and I don't understand the procedure that one enables debug first then strip the symbols during install...