### PR TITLE
Added "fullscreen" group option to force a window to open fullscreen.

### DIFF
--- a/jwm.1.in
+++ b/jwm.1.in
@@ -654,6 +654,12 @@ The desktop on which windows in this group will be started.
 .RE
 
 .P
+.B fullscreen
+.RS
+Make windows in this group initially fullscreen.
+.RE
+
+.P
 .B hmax
 .RS
 Make windows in this group maximize horizontally.

--- a/src/group.c
+++ b/src/group.c
@@ -303,6 +303,9 @@ void ApplyGroup(const GroupType *gp, ClientNode *np)
       case OPTION_CONSTRAIN:
          np->state.border |= BORDER_CONSTRAIN;
          break;
+      case OPTION_FULLSCREEN:
+         np->state.status |= STAT_FULLSCREEN;
+         break;
       default:
          Debug("invalid option: %d", lp->option);
          break;

--- a/src/group.h
+++ b/src/group.h
@@ -40,6 +40,7 @@ typedef unsigned char OptionType;
 #define OPTION_NOPAGER     22    /**< Do not show in pager. */
 #define OPTION_NOTURGENT   23    /**< Ignore the urgency hint. */
 #define OPTION_CONSTRAIN   24    /**< Constrain the window to the screen. */
+#define OPTION_FULLSCREEN  25    /**< Start fullscreen. */
 
 /*@{*/
 #define InitializeGroups() (void)(0)

--- a/src/parse.c
+++ b/src/parse.c
@@ -104,6 +104,7 @@ static const OptionMapType OPTION_MAP[] = {
    { "centered",           OPTION_CENTERED      },
    { "tiled",              OPTION_TILED         },
    { "constrain",          OPTION_CONSTRAIN     },
+   { "fullscreen",         OPTION_FULLSCREEN    },
    { NULL,                 OPTION_INVALID       }
 };
 


### PR DESCRIPTION
This change will add a "fullscreen" group option (includes update of the manpage). This forces a window to be initially fullscreen. I implemented this for use with Rollemup Pinball, which for some reason did not run fullscreen under JWM, ~~though it does so under other window managers~~.

If you want to try it yourself, the game is available from http://www.pro-linux.de/files/rollemup/Rollemup.tar.gz (i386 binaries). It requires the rather ancient libstdc++.so.2.8 (e.g. available in the [compat-libstdc++ package of Fedora 3](http://ftp.pbone.net/mirror/archive.fedoraproject.org/fedora/linux/core/3/i386/os/Fedora/RPMS/compat-libstdc++-8-3.3.4.2.i386.rpm)). Before running the game it's best to run `xrandr -s 640x480`; the game does not set the screen resolution itself.
