### PR TITLE
Ignore Automake config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 *.o
 Makefile
 autom4te.cache
+config.guess
 config.h
 config.h.in
 config.log
 config.status
+config.sub
 configure
 jwm.1
 po/Makefile


### PR DESCRIPTION
These files need to be updated by autoreconf for every new release, we shouldn't ship these files in vcs repo.