### PR TITLE
Fix build on hurd-i386

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -409,8 +409,10 @@ void StartupConnection(void)
    sigaction(SIGTERM, &sa, NULL);
    sigaction(SIGINT, &sa, NULL);
    sigaction(SIGHUP, &sa, NULL);
-
-   sa.sa_flags = SA_NOCLDWAIT;
+   
+   #ifdef SA_NOCLDWAIT
+      sa.sa_flags = SA_NOCLDWAIT;
+   #endif
    sa.sa_handler = SIG_DFL;
    sigaction(SIGCHLD, &sa, NULL);
 


### PR DESCRIPTION
The building of jwm for hurd-i386 on Debian is reporting the following:

gcc -c -g -O2 -fPIE -fstack-protector-strong -Wformat -Werror=format-security -I/usr/include/libpng12 -pthread -I/usr/include/librsvg-2.0 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libpng12 -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/i386-gnu/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng12 -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/i386-gnu/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng12  -I/usr/include/freetype2 -I/usr/include/freetype2  -I/usr/include/fribidi -DLOCALEDIR=\"/usr/share/locale\" -Wdate-time -D_FORTIFY_SOURCE=2 main.c
main.c: In function 'StartupConnection':
main.c:413:18: error: 'SA_NOCLDWAIT' undeclared (first use in this function)
    sa.sa_flags = SA_NOCLDWAIT;
                  ^
main.c:413:18: note: each undeclared identifier is reported only once for each function it appears in
Makefile:37: recipe for target 'main.o' failed
make[2]: *** [main.o] Error 1
make[2]: Leaving directory '/«PKGBUILDDIR»/src'
Makefile:8: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/«PKGBUILDDIR»'
dh_auto_build: make -j1 returned exit code 2
debian/rules:11: recipe for target 'build-arch' failed
make: *** [build-arch] Error 2