### PR TITLE
Add Aero Snap

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -83,7 +83,7 @@ typedef unsigned int StatusFlags;
 #define STAT_ILIST      (1 << 25)   /**< Ignore program-specified list. */
 #define STAT_IPAGER     (1 << 26)   /**< Ignore program-specified pager. */
 #define STAT_FIXED      (1 << 27)   /**< Keep on the specified desktop. */
-#define STAT_AEROSNAP   (1 << 28)   /**< Aero Snap. */
+#define STAT_NOAEROSNAP (1 << 28)   /**< Disallow Aero Snap. */
 
 /** Maximization flags. */
 typedef unsigned char MaxFlags;

--- a/src/client.h
+++ b/src/client.h
@@ -83,6 +83,7 @@ typedef unsigned int StatusFlags;
 #define STAT_ILIST      (1 << 25)   /**< Ignore program-specified list. */
 #define STAT_IPAGER     (1 << 26)   /**< Ignore program-specified pager. */
 #define STAT_FIXED      (1 << 27)   /**< Keep on the specified desktop. */
+#define STAT_AEROSNAP   (1 << 28)   /**< Aero Snap. */
 
 /** Maximization flags. */
 typedef unsigned char MaxFlags;

--- a/src/group.c
+++ b/src/group.c
@@ -343,6 +343,9 @@ void ApplyGroup(const GroupType *gp, ClientNode *np)
       case OPTION_FIXED:
          np->state.status |= STAT_FIXED;
          break;
+      case OPTION_NOAEROSNAP:
+         np->state.status &= ~STAT_AEROSNAP;
+         break;
       default:
          Debug("invalid option: %d", lp->option);
          break;

--- a/src/group.c
+++ b/src/group.c
@@ -344,7 +344,7 @@ void ApplyGroup(const GroupType *gp, ClientNode *np)
          np->state.status |= STAT_FIXED;
          break;
       case OPTION_NOAEROSNAP:
-         np->state.status &= ~STAT_AEROSNAP;
+         np->state.status |= STAT_NOAEROSNAP;
          break;
       default:
          Debug("invalid option: %d", lp->option);

--- a/src/group.h
+++ b/src/group.h
@@ -51,6 +51,7 @@ typedef unsigned char OptionType;
 #define OPTION_ILIST          33    /**< Ignore program-specified list. */
 #define OPTION_IPAGER         34    /**< Ignore program-specified pager. */
 #define OPTION_FIXED          35    /**< Keep on the specified desktop. */
+#define OPTION_NOAEROSNAP     36    /**< Disallow Aero Snap. */
 
 /*@{*/
 #define InitializeGroups() (void)(0)

--- a/src/move.c
+++ b/src/move.c
@@ -110,10 +110,10 @@ char MoveClient(ClientNode *np, int startx, int starty)
       return 0;
    }
    
-   if(np->state.status & STAT_AEROSNAP) {
-      aeroSnap = 1;
-   } else {
+   if(np->state.status & STAT_NOAEROSNAP) {
       aeroSnap = 0;
+   } else {
+      aeroSnap = 1;
    }
 
    if(!GrabMouseForMove()) {

--- a/src/move.c
+++ b/src/move.c
@@ -75,11 +75,7 @@ static void ToggleMaximized(ClientNode *np, MaxFlags flags);
 void ToggleMaximized(ClientNode *np, MaxFlags flags)
 {
    if(np) {
-      if(np->state.maxFlags == flags) {
-         MaximizeClient(np, MAX_NONE);
-      } else {
-         MaximizeClient(np, flags);
-      }
+      MaximizeClient(np, flags);
    }
 }
 

--- a/src/move.c
+++ b/src/move.c
@@ -190,24 +190,50 @@ char MoveClient(ClientNode *np, int startx, int starty)
             }
          } else {
             /* If alt is not pressed, snap to borders. */
-            if(atLeft) {
-               if(atTop & !(np->state.maxFlags & MAX_TOP & MAX_LEFT)) {
-                  MaximizeClient(np, MAX_TOP | MAX_LEFT);
-               } else if(atBottom & !(np->state.maxFlags & MAX_BOTTOM & MAX_LEFT)) {
-                  MaximizeClient(np, MAX_BOTTOM | MAX_LEFT);
-               } else if(!(np->state.maxFlags & MAX_LEFT & MAX_VERT)) {
+            if(atTop & atLeft) {
+               if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_LEFT))) {
+                  if(np->state.maxFlags & MAX_VERT & MAX_HORIZ) {
+                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+                  } else {
+                     MaximizeClient(np, MAX_TOP | MAX_LEFT);
+                  }
+               }
+            } else if(atTop & atRight) {
+               if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_RIGHT))) {
+                  if(np->state.maxFlags & MAX_VERT & MAX_HORIZ) {
+                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+                  } else {
+                     MaximizeClient(np, MAX_TOP | MAX_RIGHT);
+                  }
+               }
+            } else if(atBottom & atLeft) {
+               if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_LEFT))) {
+                  if(np->state.maxFlags & MAX_VERT & MAX_HORIZ) {
+                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+                  } else {
+                     MaximizeClient(np, MAX_BOTTOM | MAX_LEFT);
+                  }
+               }
+            } else if(atBottom & atRight) {
+               if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_RIGHT))) {
+                  if(np->state.maxFlags & MAX_VERT & MAX_HORIZ) {
+                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+                  } else {
+                     MaximizeClient(np, MAX_BOTTOM | MAX_RIGHT);
+                  }
+               }
+            } else if(atLeft) {
+               if(!(np->state.maxFlags & MAX_LEFT & MAX_VERT)) {
                   MaximizeClient(np, MAX_LEFT | MAX_VERT);
                }
             } else if(atRight) {
-               if(atTop & !(np->state.maxFlags & MAX_TOP & MAX_RIGHT)) {
-                  MaximizeClient(np, MAX_TOP | MAX_RIGHT);
-               } else if(atBottom & !(np->state.maxFlags & MAX_BOTTOM & MAX_RIGHT)) {
-                  MaximizeClient(np, MAX_BOTTOM | MAX_RIGHT);
-               } else if(!(np->state.maxFlags & MAX_RIGHT & MAX_VERT)) {
+               if(!(np->state.maxFlags & MAX_RIGHT & MAX_VERT)) {
                   MaximizeClient(np, MAX_RIGHT | MAX_VERT);
                }
-            } else if((atTop | atBottom) & !(np->state.maxFlags & MAX_VERT & MAX_HORIZ)) {
-               MaximizeClient(np, MAX_VERT | MAX_HORIZ);
+            } else if(atTop | atBottom) {
+               if(!(np->state.maxFlags & MAX_VERT & MAX_HORIZ)) {
+                  MaximizeClient(np, MAX_VERT | MAX_HORIZ);
+               }
             } else {
                if(np->state.maxFlags != MAX_NONE) {
                   MaximizeClient(np, MAX_NONE);

--- a/src/move.c
+++ b/src/move.c
@@ -69,16 +69,6 @@ static char CheckBottomValid(const RectangleType *client,
 static void SignalMove(const TimeType *now, int x, int y, Window w, void *data);
 static void UpdateDesktop(const TimeType *now);
 
-static void ToggleMaximized(ClientNode *np, MaxFlags flags);
-
-/** Toggle maximized state. */
-void ToggleMaximized(ClientNode *np, MaxFlags flags)
-{
-   if(np) {
-      MaximizeClient(np, flags);
-   }
-}
-
 /** Callback for stopping moves. */
 void MoveController(int wasDestroyed)
 {
@@ -201,13 +191,13 @@ char MoveClient(ClientNode *np, int startx, int starty)
          } else {
             /* If alt is not pressed, snap to borders. */
             if(atLeft) {
-               ToggleMaximized(np, MAX_LEFT | MAX_VERT);
+               MaximizeClient(np, MAX_LEFT | MAX_VERT);
             } else if(atRight) {
-               ToggleMaximized(np, MAX_RIGHT | MAX_VERT);
+               MaximizeClient(np, MAX_RIGHT | MAX_VERT);
             } else if(atTop) {
-               ToggleMaximized(np, MAX_TOP | MAX_HORIZ);
+               MaximizeClient(np, MAX_TOP | MAX_HORIZ);
             } else if(atBottom) {
-               ToggleMaximized(np, MAX_BOTTOM | MAX_HORIZ);
+               MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
             } else {
                DoSnap(np);
             }

--- a/src/move.c
+++ b/src/move.c
@@ -191,18 +191,18 @@ char MoveClient(ClientNode *np, int startx, int starty)
          } else {
             /* If alt is not pressed, snap to borders. */
             if(atLeft) {
-               if(atTop & !(np->state.maxFlags & MAX_TOP & MAX_HORIZ)) {
-                  MaximizeClient(np, MAX_TOP | MAX_HORIZ);
-               } else if(atBottom & !(np->state.maxFlags & MAX_BOTTOM & MAX_HORIZ)) {
-                  MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+               if(atTop & !(np->state.maxFlags & MAX_TOP & MAX_LEFT)) {
+                  MaximizeClient(np, MAX_TOP | MAX_LEFT);
+               } else if(atBottom & !(np->state.maxFlags & MAX_BOTTOM & MAX_LEFT)) {
+                  MaximizeClient(np, MAX_BOTTOM | MAX_LEFT);
                } else if(!(np->state.maxFlags & MAX_LEFT & MAX_VERT)) {
                   MaximizeClient(np, MAX_LEFT | MAX_VERT);
                }
             } else if(atRight) {
-               if(atTop & !(np->state.maxFlags & MAX_TOP & MAX_HORIZ)) {
-                  MaximizeClient(np, MAX_TOP | MAX_HORIZ);
-               } else if(atBottom & !(np->state.maxFlags & MAX_BOTTOM & MAX_HORIZ)) {
-                  MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+               if(atTop & !(np->state.maxFlags & MAX_TOP & MAX_RIGHT)) {
+                  MaximizeClient(np, MAX_TOP | MAX_RIGHT);
+               } else if(atBottom & !(np->state.maxFlags & MAX_BOTTOM & MAX_RIGHT)) {
+                  MaximizeClient(np, MAX_BOTTOM | MAX_RIGHT);
                } else if(!(np->state.maxFlags & MAX_RIGHT & MAX_VERT)) {
                   MaximizeClient(np, MAX_RIGHT | MAX_VERT);
                }

--- a/src/move.c
+++ b/src/move.c
@@ -69,6 +69,20 @@ static char CheckBottomValid(const RectangleType *client,
 static void SignalMove(const TimeType *now, int x, int y, Window w, void *data);
 static void UpdateDesktop(const TimeType *now);
 
+static void ToggleMaximized(ClientNode *np, MaxFlags flags);
+
+/** Toggle maximized state. */
+void ToggleMaximized(ClientNode *np, MaxFlags flags)
+{
+   if(np) {
+      if(np->state.maxFlags == flags) {
+         MaximizeClient(np, MAX_NONE);
+      } else {
+         MaximizeClient(np, flags);
+      }
+   }
+}
+
 /** Callback for stopping moves. */
 void MoveController(int wasDestroyed)
 {

--- a/src/move.c
+++ b/src/move.c
@@ -191,31 +191,25 @@ char MoveClient(ClientNode *np, int startx, int starty)
          } else {
             /* If alt is not pressed, snap to borders. */
             if(atLeft) {
-               if(np->state.maxFlags != flags) {
-                  if(atTop) {
-                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
-                  } else if(atBottom) {
-                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
-                  } else {
-                     MaximizeClient(np, MAX_LEFT | MAX_VERT);
-                  }
+               if(atTop & !(np->state.maxFlags & MAX_TOP & MAX_HORIZ)) {
+                  MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+               } else if(atBottom & !(np->state.maxFlags & MAX_BOTTOM & MAX_HORIZ)) {
+                  MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+               } else if(!(np->state.maxFlags & MAX_LEFT & MAX_VERT)) {
+                  MaximizeClient(np, MAX_LEFT | MAX_VERT);
                }
             } else if(atRight) {
-               if(np->state.maxFlags != flags) {
-                  if(atTop) {
-                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
-                  } else if (atBottom) {
-                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
-                  } else {
-                     MaximizeClient(np, MAX_RIGHT | MAX_VERT);
-                  }
+               if(atTop & !(np->state.maxFlags & MAX_TOP & MAX_HORIZ)) {
+                  MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+               } else if(atBottom & !(np->state.maxFlags & MAX_BOTTOM & MAX_HORIZ)) {
+                  MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+               } else if(!(np->state.maxFlags & MAX_RIGHT & MAX_VERT)) {
+                  MaximizeClient(np, MAX_RIGHT | MAX_VERT);
                }
-            } else if(atTop || atBottom) {
-               if(np->state.maxFlags != flags) {
-                  MaximizeClient(np, MAX_VERT | MAX_HORIZ);
-               }
+            } else if((atTop | atBottom) & !(np->state.maxFlags & MAX_VERT & MAX_HORIZ)) {
+               MaximizeClient(np, MAX_VERT | MAX_HORIZ);
             } else {
-               if(np->state.maxFlags == flags) {
+               if(np->state.maxFlags != MAX_NONE) {
                   MaximizeClient(np, MAX_NONE);
                }
                DoSnap(np);

--- a/src/move.c
+++ b/src/move.c
@@ -191,13 +191,23 @@ char MoveClient(ClientNode *np, int startx, int starty)
          } else {
             /* If alt is not pressed, snap to borders. */
             if(atLeft) {
-               MaximizeClient(np, MAX_LEFT | MAX_VERT);
+               if(atTop) {
+                  MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+               } else if(atBottom) {
+                  MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+               } else {
+                  MaximizeClient(np, MAX_LEFT | MAX_VERT);
+               }
             } else if(atRight) {
-               MaximizeClient(np, MAX_RIGHT | MAX_VERT);
-            } else if(atTop) {
-               MaximizeClient(np, MAX_TOP | MAX_HORIZ);
-            } else if(atBottom) {
-               MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+               if(atTop) {
+                  MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+               } else if (atBottom) {
+                  MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+               } else {
+                  MaximizeClient(np, MAX_RIGHT | MAX_VERT);
+               }
+            } else if(atTop || atBottom) {
+               MaximizeClient(np, MAX_VERT | MAX_HORIZ);
             } else {
                DoSnap(np);
             }

--- a/src/move.c
+++ b/src/move.c
@@ -191,24 +191,33 @@ char MoveClient(ClientNode *np, int startx, int starty)
          } else {
             /* If alt is not pressed, snap to borders. */
             if(atLeft) {
-               if(atTop) {
-                  MaximizeClient(np, MAX_TOP | MAX_HORIZ);
-               } else if(atBottom) {
-                  MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
-               } else {
-                  MaximizeClient(np, MAX_LEFT | MAX_VERT);
+               if(np->state.maxFlags != flags) {
+                  if(atTop) {
+                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+                  } else if(atBottom) {
+                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+                  } else {
+                     MaximizeClient(np, MAX_LEFT | MAX_VERT);
+                  }
                }
             } else if(atRight) {
-               if(atTop) {
-                  MaximizeClient(np, MAX_TOP | MAX_HORIZ);
-               } else if (atBottom) {
-                  MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
-               } else {
-                  MaximizeClient(np, MAX_RIGHT | MAX_VERT);
+               if(np->state.maxFlags != flags) {
+                  if(atTop) {
+                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+                  } else if (atBottom) {
+                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+                  } else {
+                     MaximizeClient(np, MAX_RIGHT | MAX_VERT);
+                  }
                }
             } else if(atTop || atBottom) {
-               MaximizeClient(np, MAX_VERT | MAX_HORIZ);
+               if(np->state.maxFlags != flags) {
+                  MaximizeClient(np, MAX_VERT | MAX_HORIZ);
+               }
             } else {
+               if(np->state.maxFlags == flags) {
+                  MaximizeClient(np, MAX_NONE);
+               }
                DoSnap(np);
             }
          }

--- a/src/move.c
+++ b/src/move.c
@@ -195,7 +195,6 @@ char MoveClient(ClientNode *np, int startx, int starty)
                if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_LEFT))) {
                   if(atSide) {
                      MaximizeClient(np, MAX_TOP | MAX_LEFT);
-                     atSide = 0;
                   } else {
                      MaximizeClient(np, MAX_TOP | MAX_HORIZ);
                   }
@@ -204,7 +203,6 @@ char MoveClient(ClientNode *np, int startx, int starty)
                if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_RIGHT))) {
                   if(atSide) {
                      MaximizeClient(np, MAX_TOP | MAX_RIGHT);
-                     atSide = 0;
                   } else {
                      MaximizeClient(np, MAX_TOP | MAX_HORIZ);
                   }
@@ -213,7 +211,6 @@ char MoveClient(ClientNode *np, int startx, int starty)
                if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_LEFT))) {
                   if(atSide) {
                      MaximizeClient(np, MAX_BOTTOM | MAX_LEFT);
-                     atSide = 0;
                   } else {
                      MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
                   }
@@ -222,7 +219,6 @@ char MoveClient(ClientNode *np, int startx, int starty)
                if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_RIGHT))) {
                   if(atSide) {
                      MaximizeClient(np, MAX_BOTTOM | MAX_RIGHT);
-                     atSide = 0;
                   } else {
                      MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
                   }

--- a/src/move.c
+++ b/src/move.c
@@ -191,7 +191,11 @@ char MoveClient(ClientNode *np, int startx, int starty)
          } else {
             /* If alt is not pressed, snap to borders. */
             if(atTop & atLeft) {
-               if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_LEFT))) {
+               if(np->state.maxFlags & MAX_TOP & MAX_LEFT) {
+                  
+               } else if(np->state.maxFlags & MAX_TOP & MAX_HORIZ) {
+                  
+               } else {
                   if(np->state.maxFlags & MAX_VERT & MAX_HORIZ) {
                      MaximizeClient(np, MAX_TOP | MAX_HORIZ);
                   } else {

--- a/src/move.c
+++ b/src/move.c
@@ -37,6 +37,7 @@ static char atRight;
 static char atBottom;
 static char atTop;
 static char atSide;
+static char aeroSnap;
 static ClientNode *currentClient;
 static TimeType moveTime;
 
@@ -107,6 +108,12 @@ char MoveClient(ClientNode *np, int startx, int starty)
    }
    if(np->state.status & STAT_FULLSCREEN) {
       return 0;
+   }
+   
+   if(np->state.status & STAT_AEROSNAP) {
+      aeroSnap = 1;
+   } else {
+      aeroSnap = 0;
    }
 
    if(!GrabMouseForMove()) {
@@ -191,57 +198,61 @@ char MoveClient(ClientNode *np, int startx, int starty)
             }
          } else {
             /* If alt is not pressed, snap to borders. */
-            if(atTop & atLeft) {
-               if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_LEFT))) {
-                  if(atSide) {
-                     MaximizeClient(np, MAX_TOP | MAX_LEFT);
-                  } else {
-                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+            if(aeroSnap) {
+               if(atTop & atLeft) {
+                  if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_LEFT))) {
+                     if(atSide) {
+                        MaximizeClient(np, MAX_TOP | MAX_LEFT);
+                     } else {
+                        MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+                     }
                   }
-               }
-            } else if(atTop & atRight) {
-               if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_RIGHT))) {
-                  if(atSide) {
-                     MaximizeClient(np, MAX_TOP | MAX_RIGHT);
-                  } else {
-                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+               } else if(atTop & atRight) {
+                  if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_RIGHT))) {
+                     if(atSide) {
+                        MaximizeClient(np, MAX_TOP | MAX_RIGHT);
+                     } else {
+                        MaximizeClient(np, MAX_TOP | MAX_HORIZ);
+                     }
                   }
-               }
-            } else if(atBottom & atLeft) {
-               if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_LEFT))) {
-                  if(atSide) {
-                     MaximizeClient(np, MAX_BOTTOM | MAX_LEFT);
-                  } else {
-                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+               } else if(atBottom & atLeft) {
+                  if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_LEFT))) {
+                     if(atSide) {
+                        MaximizeClient(np, MAX_BOTTOM | MAX_LEFT);
+                     } else {
+                        MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+                     }
                   }
-               }
-            } else if(atBottom & atRight) {
-               if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_RIGHT))) {
-                  if(atSide) {
-                     MaximizeClient(np, MAX_BOTTOM | MAX_RIGHT);
-                  } else {
-                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+               } else if(atBottom & atRight) {
+                  if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_RIGHT))) {
+                     if(atSide) {
+                        MaximizeClient(np, MAX_BOTTOM | MAX_RIGHT);
+                     } else {
+                        MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
+                     }
                   }
-               }
-            } else if(atLeft) {
-               if(!(np->state.maxFlags & MAX_LEFT & MAX_VERT)) {
-                  MaximizeClient(np, MAX_LEFT | MAX_VERT);
-                  atSide = 1;
-               }
-            } else if(atRight) {
-               if(!(np->state.maxFlags & MAX_RIGHT & MAX_VERT)) {
-                  MaximizeClient(np, MAX_RIGHT | MAX_VERT);
-                  atSide = 1;
-               }
-            } else if(atTop | atBottom) {
-               if(!(np->state.maxFlags & MAX_VERT & MAX_HORIZ)) {
-                  MaximizeClient(np, MAX_VERT | MAX_HORIZ);
-                  atSide = 0;
+               } else if(atLeft) {
+                  if(!(np->state.maxFlags & MAX_LEFT & MAX_VERT)) {
+                     MaximizeClient(np, MAX_LEFT | MAX_VERT);
+                     atSide = 1;
+                  }
+               } else if(atRight) {
+                  if(!(np->state.maxFlags & MAX_RIGHT & MAX_VERT)) {
+                     MaximizeClient(np, MAX_RIGHT | MAX_VERT);
+                     atSide = 1;
+                  }
+               } else if(atTop | atBottom) {
+                  if(!(np->state.maxFlags & MAX_VERT & MAX_HORIZ)) {
+                     MaximizeClient(np, MAX_VERT | MAX_HORIZ);
+                     atSide = 0;
+                  }
+               } else {
+                  if(np->state.maxFlags != MAX_NONE) {
+                     MaximizeClient(np, MAX_NONE);
+                  }
+                  DoSnap(np);
                }
             } else {
-               if(np->state.maxFlags != MAX_NONE) {
-                  MaximizeClient(np, MAX_NONE);
-               }
                DoSnap(np);
             }
          }

--- a/src/move.c
+++ b/src/move.c
@@ -190,7 +190,17 @@ char MoveClient(ClientNode *np, int startx, int starty)
             }
          } else {
             /* If alt is not pressed, snap to borders. */
-            DoSnap(np);
+            if(atLeft) {
+               ToggleMaximized(np, MAX_LEFT | MAX_VERT);
+            } else if(atRight) {
+               ToggleMaximized(np, MAX_RIGHT | MAX_VERT);
+            } else if(atTop) {
+               ToggleMaximized(np, MAX_TOP | MAX_HORIZ);
+            } else if(atBottom) {
+               ToggleMaximized(np, MAX_BOTTOM | MAX_HORIZ);
+            } else {
+               DoSnap(np);
+            }
          }
 
          if(!doMove && (abs(np->x - oldx) > MOVE_DELTA

--- a/src/move.c
+++ b/src/move.c
@@ -36,6 +36,7 @@ static char atLeft;
 static char atRight;
 static char atBottom;
 static char atTop;
+static char atSide;
 static ClientNode *currentClient;
 static TimeType moveTime;
 
@@ -86,7 +87,7 @@ void MoveController(int wasDestroyed)
    atBottom = 0;
    atLeft = 0;
    atRight = 0;
-
+   atSide = 0;
 }
 
 /** Move a client window. */
@@ -130,7 +131,7 @@ char MoveClient(ClientNode *np, int startx, int starty)
    starty -= north;
 
    currentClient = np;
-   atTop = atBottom = atLeft = atRight = 0;
+   atTop = atBottom = atLeft = atRight = atSide = 0;
    doMove = 0;
    for(;;) {
 
@@ -191,52 +192,55 @@ char MoveClient(ClientNode *np, int startx, int starty)
          } else {
             /* If alt is not pressed, snap to borders. */
             if(atTop & atLeft) {
-               if(np->state.maxFlags & MAX_TOP & MAX_LEFT) {
-                  
-               } else if(np->state.maxFlags & MAX_TOP & MAX_HORIZ) {
-                  
-               } else {
-                  if(np->state.maxFlags & MAX_VERT & MAX_HORIZ) {
-                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
-                  } else {
+               if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_LEFT))) {
+                  if(atSide) {
                      MaximizeClient(np, MAX_TOP | MAX_LEFT);
+                     atSide = 0;
+                  } else {
+                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
                   }
                }
             } else if(atTop & atRight) {
                if(!(np->state.maxFlags & MAX_TOP & (MAX_HORIZ | MAX_RIGHT))) {
-                  if(np->state.maxFlags & MAX_VERT & MAX_HORIZ) {
-                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
-                  } else {
+                  if(atSide) {
                      MaximizeClient(np, MAX_TOP | MAX_RIGHT);
+                     atSide = 0;
+                  } else {
+                     MaximizeClient(np, MAX_TOP | MAX_HORIZ);
                   }
                }
             } else if(atBottom & atLeft) {
                if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_LEFT))) {
-                  if(np->state.maxFlags & MAX_VERT & MAX_HORIZ) {
-                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
-                  } else {
+                  if(atSide) {
                      MaximizeClient(np, MAX_BOTTOM | MAX_LEFT);
+                     atSide = 0;
+                  } else {
+                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
                   }
                }
             } else if(atBottom & atRight) {
                if(!(np->state.maxFlags & MAX_BOTTOM & (MAX_HORIZ | MAX_RIGHT))) {
-                  if(np->state.maxFlags & MAX_VERT & MAX_HORIZ) {
-                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
-                  } else {
+                  if(atSide) {
                      MaximizeClient(np, MAX_BOTTOM | MAX_RIGHT);
+                     atSide = 0;
+                  } else {
+                     MaximizeClient(np, MAX_BOTTOM | MAX_HORIZ);
                   }
                }
             } else if(atLeft) {
                if(!(np->state.maxFlags & MAX_LEFT & MAX_VERT)) {
                   MaximizeClient(np, MAX_LEFT | MAX_VERT);
+                  atSide = 1;
                }
             } else if(atRight) {
                if(!(np->state.maxFlags & MAX_RIGHT & MAX_VERT)) {
                   MaximizeClient(np, MAX_RIGHT | MAX_VERT);
+                  atSide = 1;
                }
             } else if(atTop | atBottom) {
                if(!(np->state.maxFlags & MAX_VERT & MAX_HORIZ)) {
                   MaximizeClient(np, MAX_VERT | MAX_HORIZ);
+                  atSide = 0;
                }
             } else {
                if(np->state.maxFlags != MAX_NONE) {

--- a/src/parse.c
+++ b/src/parse.c
@@ -117,7 +117,8 @@ static const StringMappingType OPTION_MAP[] = {
    { "sticky",             OPTION_STICKY        },
    { "tiled",              OPTION_TILED         },
    { "title",              OPTION_TITLE         },
-   { "vmax",               OPTION_MAX_V         }
+   { "vmax",               OPTION_MAX_V         },
+   { "noaerosnap",         OPTION_NOAEROSNAP    }
 };
 static const unsigned int OPTION_MAP_COUNT = ARRAY_LENGTH(OPTION_MAP);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -100,6 +100,7 @@ static const StringMappingType OPTION_MAP[] = {
    { "ipager",             OPTION_IPAGER        },
    { "maximized",          OPTION_MAXIMIZED     },
    { "minimized",          OPTION_MINIMIZED     },
+   { "noaerosnap",         OPTION_NOAEROSNAP    },
    { "noborder",           OPTION_NOBORDER      },
    { "noclose",            OPTION_NOCLOSE       },
    { "nofocus",            OPTION_NOFOCUS       },
@@ -117,8 +118,7 @@ static const StringMappingType OPTION_MAP[] = {
    { "sticky",             OPTION_STICKY        },
    { "tiled",              OPTION_TILED         },
    { "title",              OPTION_TITLE         },
-   { "vmax",               OPTION_MAX_V         },
-   { "noaerosnap",         OPTION_NOAEROSNAP    }
+   { "vmax",               OPTION_MAX_V         }
 };
 static const unsigned int OPTION_MAP_COUNT = ARRAY_LENGTH(OPTION_MAP);
 


### PR DESCRIPTION
Lots of other window managers like kde, gnome, xfce, windows 7 have the feature where when you drag a window to the edge of the screen it will maximise to half the screen size. It becomes a habit after a while to just drag to the edge and I was finding it really annoying that jwm didn't have this feature and I think other people would appreciate it aswell if you added it to jwm as a default behaviour.