### PR TITLE
Change method for image type detection Issue 427

### DIFF
--- a/src/image.h
+++ b/src/image.h
@@ -53,5 +53,9 @@ ImageNode *CreateImage(unsigned int width, unsigned int height, char bitmap);
  * @param image The image to destroy.
  */
 void DestroyImage(ImageNode *image);
+/** Extracts file type by reading first few bytes
+ * @param fileName The path to the file.
+ */
+int ExtractFileType(const char *fileName);
 
 #endif /* IMAGE_H */


### PR DESCRIPTION
The proposed method uses Magic Numbers and fixed initial texts in the file.
Now the function reads 9(XPM has the longest header length-9) bytes in to a buffer and then compares it to predefined
values for every supported file formats one by one and returns specific int value.

This method also fixes a problem that used to occur in the old load function.
Lets say all of the formats are supported.Now, if the image is a corrupted JPEG, the LoadJPEGImage will return NULL.Now
ideally the program should return by now but, it carries on to check whether the extension matches with others or not.

Following are the file extensions supported:

JPEG : 0xFF , 0xD8
PNG  : 0x89 , 0x50 , 0x4E , 0x47 , 0x0D , 0x0A , 0x1A , 0x0A
SVG  : 0x3C , 0x73 , 0x76 , 0x67, 0x20 or 0x3C, 0x3F, 0x78, 0x6D, 0x6C ['<svg ' or '<?xml']
XPM  : 0x2F , 0x2A , 0x20 , 0x58 , 0x50 , 0x4D , 0x20 , 0x2A , 0x2F    ['/* XPM */']
XBM  : 0x23 , 0x64 , 0x65 , 0x66 , 0x69 , 0x6E , 0x65                  ['#define']