### PR TITLE
Add WM_CLIENT_MACHINE tag for the group settings

### DIFF
--- a/jwm.1.in
+++ b/jwm.1.in
@@ -749,8 +749,8 @@ output is the same as the main configuration file.
 .B "GROUP SETTINGS"
 .RS
 Program groups allow one to specify options which apply to a group of
-programs by name, class and window type. A program group is created with 
-the \fBGroup\fP tag. As many program groups can be created as desired.
+programs by name, class, window type and machine. A program group is created
+with the \fBGroup\fP tag. As many program groups can be created as desired.
 If one or more \fBName\fP tags is specified, at least one name must
 match.  Likewise, if one or more \fBClass\fP tags is specified, at least
 one class must match.
@@ -773,6 +773,11 @@ second string in WM_CLASS).
 The window type for a program to match to be in this group. Possible 
 values are desktop, dialog, dock, menu, normal, notification, splash,
 toolbar, utility.
+.RE
+.B Machine
+.RS
+The machine on which a program runs to match to be in this group.
+(the string WM_CLIENT_MACHINE)
 .RE
 .B Option
 .RS

--- a/src/client.h
+++ b/src/client.h
@@ -145,6 +145,7 @@ typedef struct ClientNode {
    char *name;                /**< Name of this window for display. */
    char *instanceName;        /**< Name of this window for properties. */
    char *className;           /**< Name of the window class. */
+   char *machineName;         /**< Name of the machine. */
 
    ClientState state;         /**< Window state. */
 

--- a/src/event.c
+++ b/src/event.c
@@ -951,8 +951,10 @@ char HandlePropertyNotify(const XPropertyEvent *event)
          JXGetTransientForHint(display, np->window, &np->owner);
          break;
       case XA_WM_ICON_NAME:
-      case XA_WM_CLIENT_MACHINE:
          break;
+      case XA_WM_CLIENT_MACHINE:
+         ReadWMMachine(np);
+         changed = 1;
       default:
          if(event->atom == atoms[ATOM_WM_COLORMAP_WINDOWS]) {
             ReadWMColormaps(np);

--- a/src/group.c
+++ b/src/group.c
@@ -18,9 +18,10 @@
 
 /** What part of the window to match. */
 typedef unsigned int MatchType;
-#define MATCH_NAME   0  /**< Match the window name. */
-#define MATCH_CLASS  1  /**< Match the window class. */
-#define MATCH_TYPE   2  /**< Match the window type. */
+#define MATCH_NAME      0  /**< Match the window name. */
+#define MATCH_CLASS     1  /**< Match the window class. */
+#define MATCH_TYPE      2  /**< Match the window type. */
+#define MATCH_MACHINE   3  /**< Match the window machine. */
 
 /** List of match patterns for a group. */
 typedef struct PatternListType {
@@ -139,6 +140,17 @@ void AddGroupType(GroupType *gp, const char *pattern)
    }
 }
 
+/** Add a window machine to a group. */
+void AddGroupMachine(GroupType *gp, const char *pattern)
+{
+   Assert(gp);
+   if(JLIKELY(pattern)) {
+      AddPattern(&gp->patterns, pattern, MATCH_MACHINE);
+   } else {
+      Warning(_("invalid group machine"));
+   }
+}
+
 /** Add a pattern to a pattern list. */
 void AddPattern(PatternListType **lp, const char *pattern, MatchType match)
 {
@@ -212,9 +224,11 @@ void ApplyGroups(ClientNode *np)
    char hasClass;
    char hasName;
    char hasType;
+   char hasMachine;
    char matchesClass;
    char matchesName;
    char matchesType;
+   char matchesMachine;
 
    static const StringMappingType windowTypeMapping[] = {
       { "desktop",      WINDOW_TYPE_DESKTOP      },
@@ -236,6 +250,7 @@ void ApplyGroups(ClientNode *np)
       matchesClass = 0;
       matchesName = 0;
       matchesType = 0;
+      matchesMachine = 0;
       for(lp = gp->patterns; lp; lp = lp->next) {
          if(lp->match == MATCH_CLASS) {
             if(Match(lp->pattern, np->className)) {
@@ -253,12 +268,17 @@ void ApplyGroups(ClientNode *np)
                 matchesType = 1;
              }
              hasType = 1;
+         } else if(lp->match == MATCH_MACHINE) {
+            if(Match(lp->pattern, np->machineName)) {
+               matchesMachine = 1;
+            }
+             hasMachine = 1;
          } else {
             Debug("invalid match in ApplyGroups: %d", lp->match);
          }
       }
       if(hasName == matchesName && hasClass == matchesClass
-      && hasType == matchesType) {
+      && hasType == matchesType && hasMachine == matchesMachine) {
          ApplyGroup(gp, np);
       }
    }

--- a/src/group.h
+++ b/src/group.h
@@ -88,6 +88,12 @@ void AddGroupName(struct GroupType *gp, const char *pattern);
  */
 void AddGroupType(struct GroupType *gp, const char *pattern);
 
+/** Add a window machine to a group.
+ * @param gp The group.
+ * @param pattern A pattern to match with the window type.
+ */
+void AddGroupMachine(struct GroupType *gp, const char *pattern);
+
 /** Add a group option that doesn't take a value.
  * @param gp The group.
  * @param option The option.

--- a/src/hint.c
+++ b/src/hint.c
@@ -297,6 +297,7 @@ void ReadClientInfo(ClientNode *np, char alreadyMapped)
    ReadWMClass(np);
    ReadWMNormalHints(np);
    ReadWMColormaps(np);
+   ReadWMMachine(np);
 
    status = JXGetTransientForHint(display, np->window, &np->owner);
    if(!status) {
@@ -785,6 +786,23 @@ void ReadWMName(ClientNode *np)
       }
    }
 
+}
+
+/** Read the machine for a client. */
+void ReadWMMachine(ClientNode *np)
+{
+   XTextProperty tprop;
+   char **tlist;
+   int tcount;
+   
+   XGetWMClientMachine(display, np->window, &tprop);
+   if(XmbTextPropertyToTextList(display, &tprop, &tlist, &tcount)
+      == Success && tcount > 0) {
+      const size_t len = strlen(tlist[0]) + 1;
+      np->machineName = Allocate(len);
+      memcpy(np->machineName, tlist[0], len);
+      XFreeStringList(tlist);
+   }
 }
 
 /** Read the window class for a client. */

--- a/src/hint.h
+++ b/src/hint.h
@@ -193,6 +193,11 @@ void ReadClientInfo(struct ClientNode *np, char alreadyMapped);
  */
 void ReadWMName(struct ClientNode *np);
 
+/** Read a client's machine.
+ * @param np The client.
+ */
+void ReadWMMachine(struct ClientNode *np);
+
 /** Read a client's class.
  * @param np The client.
  */

--- a/src/lex.c
+++ b/src/lex.c
@@ -51,6 +51,7 @@ static const StringMappingType TOKEN_MAP[] = {
    { "Key",                TOK_KEY              },
    { "Kill",               TOK_KILL             },
    { "Layer",              TOK_LAYER            },
+   { "Machine",            TOK_MACHINE          },
    { "Maximize",           TOK_MAXIMIZE         },
    { "Menu",               TOK_MENU             },
    { "MenuStyle",          TOK_MENUSTYLE        },

--- a/src/lex.h
+++ b/src/lex.h
@@ -47,6 +47,7 @@ typedef enum {
    TOK_KEY,
    TOK_KILL,
    TOK_LAYER,
+   TOK_MACHINE,
    TOK_MAXIMIZE,
    TOK_MENU,
    TOK_MENUSTYLE,

--- a/src/parse.c
+++ b/src/parse.c
@@ -1823,6 +1823,9 @@ void ParseGroup(const TokenNode *tp)
       case TOK_TYPE:
          AddGroupType(group, np->value);
          break;
+      case TOK_MACHINE:
+         AddGroupMachine(group, np->value);
+         break;
       case TOK_OPTION:
          ParseGroupOption(np, group, np->value);
          break;


### PR DESCRIPTION
This may be beneficial for more users then just me: use WM_CLIENT_MACHINE (as `<Group><Machine>foo</Machine>...`) , so programs startet from a different host (e.g. ssh -X ...) can be grouped.