### PR TITLE
Fix a showing of title text

### DIFF
--- a/src/border.c
+++ b/src/border.c
@@ -453,7 +453,7 @@ void DrawBorderHelper(const ClientNode *np)
 
          switch (settings.titleTextAlignment) {
          case ALIGN_CENTER:
-            xoffset = (titleWidth - textWidth) / 2;
+            xoffset = (int)(titleWidth - textWidth) / 2;
             break;
          case ALIGN_RIGHT:
             xoffset = (titleWidth - textWidth);


### PR DESCRIPTION
Fix a showing of title text when text width is larger than the width of the title and centered or right aligned