### PR TITLE
configure.ac : gettext 19 -> 20

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -489,7 +489,7 @@ fi
 ############################################################################
 AM_ICONV
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.19])
+AM_GNU_GETTEXT_VERSION([0.20])
 LDFLAGS="$LDFLAGS $LIBINTL $LIBICONV"
 
 ############################################################################


### PR DESCRIPTION
gettext 19 is very obsolete

it's working just fine with version 20