### PR TITLE
Add a group of programs by window display name

### DIFF
--- a/jwm.1.in
+++ b/jwm.1.in
@@ -785,6 +785,11 @@ toolbar, utility.
 The machine on which a program runs to match to be in this group.
 (the string WM_CLIENT_MACHINE)
 .RE
+.B WindowName
+.RS
+The window display name of a program to match to be in this group
+(the name in the title bar)
+.RE
 .B Option
 .RS
 An option for this group. Possible options are:

--- a/src/group.c
+++ b/src/group.c
@@ -22,6 +22,7 @@ typedef unsigned int MatchType;
 #define MATCH_CLASS     1  /**< Match the window class. */
 #define MATCH_TYPE      2  /**< Match the window type. */
 #define MATCH_MACHINE   3  /**< Match the window machine. */
+#define MATCH_WNAME     4  /**< Match the window display name. */
 
 /** List of match patterns for a group. */
 typedef struct PatternListType {
@@ -151,6 +152,17 @@ void AddGroupMachine(GroupType *gp, const char *pattern)
    }
 }
 
+/** Add a window name to a group. */
+void AddGroupWindowName(GroupType *gp, const char *pattern)
+{
+   Assert(gp);
+   if(JLIKELY(pattern)) {
+      AddPattern(&gp->patterns, pattern, MATCH_WNAME);
+   } else {
+      Warning(_("invalid group window name"));
+   }
+}
+
 /** Add a pattern to a pattern list. */
 void AddPattern(PatternListType **lp, const char *pattern, MatchType match)
 {
@@ -225,10 +237,12 @@ void ApplyGroups(ClientNode *np)
    char hasName;
    char hasType;
    char hasMachine;
+   char hasWindowName;
    char matchesClass;
    char matchesName;
    char matchesType;
    char matchesMachine;
+   char matchesWindowName;
 
    static const StringMappingType windowTypeMapping[] = {
       { "desktop",      WINDOW_TYPE_DESKTOP      },
@@ -248,10 +262,12 @@ void ApplyGroups(ClientNode *np)
       hasName = 0;
       hasType = 0;
       hasMachine = 0;
+      hasWindowName = 0;
       matchesClass = 0;
       matchesName = 0;
       matchesType = 0;
       matchesMachine = 0;
+      matchesWindowName = 0;
       for(lp = gp->patterns; lp; lp = lp->next) {
          if(lp->match == MATCH_CLASS) {
             if(Match(lp->pattern, np->className)) {
@@ -274,12 +290,18 @@ void ApplyGroups(ClientNode *np)
                matchesMachine = 1;
             }
              hasMachine = 1;
+         } else if(lp->match == MATCH_WNAME) {
+            if(Match(lp->pattern, np->name)) {
+               matchesWindowName = 1;
+            }
+            hasWindowName = 1;
          } else {
             Debug("invalid match in ApplyGroups: %d", lp->match);
          }
       }
       if(hasName == matchesName && hasClass == matchesClass
-      && hasType == matchesType && hasMachine == matchesMachine) {
+      && hasType == matchesType && hasMachine == matchesMachine
+      && hasWindowName == matchesWindowName) {
          ApplyGroup(gp, np);
       }
    }

--- a/src/group.h
+++ b/src/group.h
@@ -89,6 +89,12 @@ void AddGroupName(struct GroupType *gp, const char *pattern);
  */
 void AddGroupType(struct GroupType *gp, const char *pattern);
 
+/** Add a window display name to a group.
+ * @param gp The group.
+ * @param pattern A pattern to match with the window display name.
+ */
+void AddGroupWindowName(struct GroupType *gp, const char *pattern);
+
 /** Add a window machine to a group.
  * @param gp The group.
  * @param pattern A pattern to match with the window type.

--- a/src/lex.c
+++ b/src/lex.c
@@ -92,6 +92,7 @@ static const StringMappingType TOKEN_MAP[] = {
    { "TrayStyle",          TOK_TRAYSTYLE        },
    { "Type",               TOK_TYPE             },
    { "Width",              TOK_WIDTH            },
+   { "WindowName",         TOK_WINDOWNAME       },
    { "WindowStyle",        TOK_WINDOWSTYLE      }
 };
 static const unsigned int TOKEN_MAP_COUNT = ARRAY_LENGTH(TOKEN_MAP);

--- a/src/lex.h
+++ b/src/lex.h
@@ -88,6 +88,7 @@ typedef enum {
    TOK_TRAYSTYLE,
    TOK_TYPE,
    TOK_WIDTH,
+   TOK_WINDOWNAME,
    TOK_WINDOWSTYLE
 
 } TokenType;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1834,6 +1834,9 @@ void ParseGroup(const TokenNode *tp)
       case TOK_MACHINE:
          AddGroupMachine(group, np->value);
          break;
+      case TOK_WINDOWNAME:
+         AddGroupWindowName(group, np->value);
+         break;
       case TOK_OPTION:
          ParseGroupOption(np, group, np->value);
          break;


### PR DESCRIPTION
With this patch, groups can be formed using the window display name (the name in the title bar). I need this for VMware because I need a group for the main window but all window has the same resource name, class and type.