### PR TITLE
Middle click close on taskbar

### DIFF
--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -353,6 +353,11 @@ FoundActiveAndTop:
             }
          }
          break;
+      case Button2:
+      	for(cp = entry->clients; cp; cp = cp->next) {
+      	   DeleteClient(cp->client);
+         }
+         break;
       case Button3:
          ShowClientList(bar, entry);
          break;


### PR DESCRIPTION
This adds a close on middle click to taskbar. Better than this would be to utilize whatever keybinding is for middle click on the titlebar context (I couldn't figure out how to get that setting). Best would be have a taskbar context for mouse keybindings so one could do whatever they wanted.

Related issue https://github.com/joewing/jwm/issues/541