### PR TITLE
Add nomaxtitle group option

### DIFF
--- a/jwm.1.in
+++ b/jwm.1.in
@@ -958,6 +958,12 @@ Do not show a border on maximized windows in this group.
 .RE
 
 .P
+.B nomaxtitle
+.RS
+Do not show a title bar on maximized windows in this group.
+.RE
+
+.P
 .B nomin
 .RS
 Prevent windows in this group from being minimized.

--- a/src/border.c
+++ b/src/border.c
@@ -433,6 +433,7 @@ void DrawBorderHelper(const ClientNode *np)
 
    /* Draw the top part (either a title or north border). */
    if((np->state.border & BORDER_TITLE) &&
+      !(np->state.maxFlags && (np->state.border & TITLE_NOMAX)) &&
       titleHeight > settings.borderWidth) {
 
       XPoint point;
@@ -1199,7 +1200,8 @@ void GetBorderSize(const ClientState *state,
       const char show_border =
          !state->maxFlags || !(state->border & BORDER_NOMAX);
 
-      if(state->border & BORDER_TITLE) {
+      if((state->border & BORDER_TITLE) &&
+         !(state->maxFlags && (state->border & TITLE_NOMAX))) {
          *north = GetTitleHeight();
       } else if(settings.windowDecorations == DECO_MOTIF) {
          *north = 0;

--- a/src/client.h
+++ b/src/client.h
@@ -35,6 +35,7 @@ typedef unsigned short BorderFlags;
 #define BORDER_CONSTRAIN   (1 << 10)   /**< Constrain to the screen. */
 #define BORDER_FULLSCREEN  (1 << 11)   /**< Allow fullscreen. */
 #define BORDER_NOMAX       (1 << 12)   /**< No border on maximize. */
+#define TITLE_NOMAX        (1 << 13)   /**< No title on maximize. */
 
 /** The default border flags. */
 #define BORDER_DEFAULT (   \

--- a/src/group.c
+++ b/src/group.c
@@ -452,6 +452,9 @@ void ApplyGroup(const GroupType *gp, ClientNode *np)
       case OPTION_NOMAXBORDER:
          np->state.border |= BORDER_NOMAX;
          break;
+      case OPTION_NOMAXTITLE:
+         np->state.border |= TITLE_NOMAX;
+         break;
       default:
          Debug("invalid option: %d", lp->option);
          break;

--- a/src/group.h
+++ b/src/group.h
@@ -58,6 +58,7 @@ typedef unsigned char OptionType;
 #define OPTION_WIDTH          40    /**< Initial window width. */
 #define OPTION_HEIGHT         41    /**< Initial window height. */
 #define OPTION_NOMAXBORDER    42    /**< No border on maximized windows. */
+#define OPTION_NOMAXTITLE     43    /**< No title on maximized windows. */
 
 /*@{*/
 #define InitializeGroups() (void)(0)

--- a/src/parse.c
+++ b/src/parse.c
@@ -127,6 +127,7 @@ static const StringMappingType OPTION_MAP[] = {
    { "nolist",             OPTION_NOLIST        },
    { "nomax",              OPTION_NOMAX         },
    { "nomaxborder",        OPTION_NOMAXBORDER   },
+   { "nomaxtitle",         OPTION_NOMAXTITLE    },
    { "nomin",              OPTION_NOMIN         },
    { "nomove",             OPTION_NOMOVE        },
    { "nopager",            OPTION_NOPAGER       },


### PR DESCRIPTION
Greetings!

This PR adds a nomaxtitle group option that is similar to the nomaxborder option. When set, windows in the group that are maximized will not show a title bar. 

Using this option in conjunction with nomaxborder is useful to allow things like terminals and web browsers to use all available screen real estate, like fullscreen, but still allows for autohidden trays and windows in the "Above" layer to be displayed above them.

Prior art:
A similar feature is available in kwin with `BorderlessMaximizedWindows` (which hides borders as well as title bar), and in xfwm4 with the `titleless_maximize` xfconf property.