### PR TITLE
Add backandforth attribute to Desktops tag

### DIFF
--- a/jwm.1.in
+++ b/jwm.1.in
@@ -1870,6 +1870,15 @@ The number of virtual desktops in the vertical direction.
 The default is 1.
 .RE
 .P
+\fBbackandforth\fP \fIstring\fP
+.RS
+Controls whether changing the desktop to the currently active desktop using
+the \fBdesktop#\fP action should instead switch to the previously active
+desktop.
+Default is "off" to do nothing when switching to the currently active desktop.
+Possible values are "on" and "off".
+.RE
+.P
 Within the \fBDesktops\fP tag the following tags are supported:
 .P
 .B Background

--- a/src/client.c
+++ b/src/client.c
@@ -49,6 +49,7 @@ void StartupClients(void)
    clientCount = 0;
    activeClient = NULL;
    currentDesktop = 0;
+   previousDesktop = 0;
 
    /* Clear out the client lists. */
    for(x = 0; x < LAYER_COUNT; x++) {

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -192,6 +192,7 @@ void ChangeDesktop(unsigned int desktop)
       }
    }
 
+   previousDesktop = currentDesktop;
    currentDesktop = desktop;
 
    SetCardinalAtom(rootWindow, ATOM_NET_CURRENT_DESKTOP, currentDesktop);

--- a/src/event.c
+++ b/src/event.c
@@ -480,12 +480,18 @@ void ProcessBinding(MouseContextType context, ClientNode *np,
 {
    const ActionType key = GetKey(context, state, code);
    const char keyAction = context == MC_NONE;
+   unsigned int desktop;
    switch(key.action) {
    case ACTION_EXEC:
       RunKeyCommand(context, state, code);
       break;
    case ACTION_DESKTOP:
-      ChangeDesktop(key.extra);
+      desktop = key.extra;
+      if(currentDesktop == desktop &&
+         settings.desktopBackAndForth) {
+           desktop = previousDesktop;
+      }
+      ChangeDesktop(desktop);
       break;
    case ACTION_RDESKTOP:
       RightDesktop();

--- a/src/main.c
+++ b/src/main.c
@@ -63,6 +63,7 @@ char initializing = 0;
 char shouldReload = 0;
 
 unsigned int currentDesktop = 0;
+unsigned int previousDesktop = 0;
 
 char *exitCommand = NULL;
 

--- a/src/main.h
+++ b/src/main.h
@@ -25,6 +25,7 @@ extern Atom managerSelection;
 extern char *exitCommand;
 
 extern unsigned int currentDesktop;
+extern unsigned int previousDesktop;
 
 extern char shouldExit;
 extern char shouldRestart;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1097,13 +1097,22 @@ void ParseInclude(const TokenNode *tp, int depth)
 
 /** Parse desktop configuration. */
 void ParseDesktops(const TokenNode *tp) {
-
+   
+   static const StringMappingType mapping[] = {
+      { "off",       DBACKANDFORTH_OFF },
+      { "on",        DBACKANDFORTH_ON  }
+   };
    TokenNode *np;
    const char *width;
    const char *height;
    int desktop;
+   DesktopBackAndForthType backandforth;
 
    Assert(tp);
+
+   backandforth = ParseAttribute(mapping, ARRAY_LENGTH(mapping), tp,
+                                 "backandforth", DBACKANDFORTH_OFF);
+   settings.desktopBackAndForth = backandforth;
 
    width = FindAttribute(tp->attributes, WIDTH_ATTRIBUTE);
    if(width != NULL) {

--- a/src/settings.c
+++ b/src/settings.c
@@ -51,6 +51,7 @@ void InitializeSettings(void)
    settings.titleTextAlignment = ALIGN_LEFT;
    settings.desktopWidth = 4;
    settings.desktopHeight = 1;
+   settings.desktopBackAndForth = DBACKANDFORTH_OFF;
    settings.menuOpacity = UINT_MAX;
    settings.windowDecorations = DECO_FLAT;
    settings.trayDecorations = DECO_FLAT;

--- a/src/settings.h
+++ b/src/settings.h
@@ -79,6 +79,11 @@ typedef unsigned char MouseContextType;
 #define MC_BORDER_E        0x40  /**< East border. */
 #define MC_BORDER_W        0x80  /**< West border. */
 
+/** Enumeration of desktop back and forth values. */
+typedef unsigned char DesktopBackAndForthType;
+#define DBACKANDFORTH_OFF 0 /**< No back and forth */
+#define DBACKANDFORTH_ON  1 /**< Enable back and forth */
+
 /** Maximimum number of title bar components
  * For now, we allow each component to be used twice. */
 #define TBC_COUNT       9
@@ -117,6 +122,7 @@ typedef struct {
    MouseContextType titleBarLayout[TBC_COUNT + 1];
    char groupTasks;
    char listAllTasks;
+   DesktopBackAndForthType desktopBackAndForth;
 } Settings;
 
 extern Settings settings;


### PR DESCRIPTION
Hello again! I have been using JWM for the past week as my daily driver and I really love how much functionality is packed into such a small and fast window manager. One thing I have been missing is a feature i3 calls `workspace_auto_back_and_forth` and xfce calls `toggle_workspaces`.

The basic idea is that when you try to switch to the currently active desktop using the `desktop#` action, it will instead switch to the previously active desktop rather than being a no-op. This is very convenient to quickly switch back and forth when working on something between two desktops (e.g., a terminal and a chat application).

For example, if I have a terminal open in desktop 1 and slack open in desktop 2, desktop 1 is currently active, and I have a keybinding like

```xml
<Key mask="4" key="#">desktop#</Key>
```

I can press mod4+2 to switch to desktop 2, and then press mod4+2 again to switch back to desktop 1. It's even more convenient when I am working between, say, desktop 5 and 1 and only need to press mod4+1 to switch back and forth.

This PR adds a `backandforth` attribute to the Desktops tag to configure this functionality. Possible values are "on" and "off" (the default). If set to "off" (or unset) the current behavior of doing nothing when switching to the currently active desktop is retained. When set to "on", the previously active desktop will be switched to instead.

There are a couple of things I am unsure about:

- Having this be configured through an attribute on the Desktops tag doesn't feel like the cleanest solution, but having a whole new tag for it seems like overkill and clutter.
- I am  not sure `backandforth` is the best name for the attribute, I basically just copied i3's naming because I couldn't think of anything better to express the idea.

Note that the checking for current desktop and swapping in the previous desktop needs to be done in `ProcessBinding` in event.c and _not_ in `ChangeDesktop` in desktop.c, so that it only applies to our own calls from the `desktop#` action and is not executed when external pagers or tools like wmctl and xdotool request to change the _NET_CURRENT_DESKTOP property. This unfortunately means the check for `currentDesktop == desktop` is duplicated in both places, but I do not see a way to avoid that.