### PR TITLE
Update pl.po

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -2,31 +2,32 @@
 # Copyright (C) 2012 Free Software Foundation, Inc.
 # This file is distributed under the same license as the jwm package.
 # Miś Uszatek <adres.email@ymail.com>, 2012
+# Faalagorn, 2022
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: 2.1.0+svn579-1\n"
 "Report-Msgid-Bugs-To: joewing@joewing.net\n"
 "POT-Creation-Date: 2022-02-26 13:28+0000\n"
-"PO-Revision-Date: 2012-09-14 16:59+0100\n"
-"Last-Translator: Miś Uszatek  <adres.email@ymail.com>\n"
+"PO-Revision-Date: 2022-05-15 14:46+0200\n"
+"Last-Translator: Faalagorn, 2022\n"
 "Language-Team: Polish <debian-l10n-polish@lists.debian.org>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || "
+"n%100>=20) ? 1 : 2);\n"
 
 #: src/action.c:44
-#, fuzzy, c-format
+#, c-format
 msgid "invalid action: \"%s\""
-msgstr "nieprawidłowa akcja TrayButton: \"%s\""
+msgstr "nieprawidłowa akcja: \"%s\""
 
 #: src/action.c:211
-#, fuzzy, c-format
+#, c-format
 msgid "action: root menu \"%s\" not defined"
-msgstr "przycisk zasobnika: menu głównym %d nie zdefiniowano"
+msgstr "akcja: nie zdefiniowano menu głównego \"%s\""
 
 #: src/background.c:137
 msgid "no value specified for background"
@@ -59,16 +60,16 @@ msgstr "nieprawidłowy modyfikator: \"%c\""
 #: src/binding.c:373
 #, c-format
 msgid "invalid key symbol: \"%s\""
-msgstr "nieprawidłowy symbol klucza: \"%s\""
+msgstr "nieprawidłowy symbol klawisza: \"%s\""
 
 #: src/binding.c:482
 msgid "neither key nor keycode specified for Key"
-msgstr "ani klucza ani keycode określony dla Key"
+msgstr "nie ma klawisza ani kodu klawisza określonego dla Key"
 
 #: src/binding.c:520
-#, fuzzy, c-format
+#, c-format
 msgid "key binding: root menu \"%s\" not defined"
-msgstr "klucz wiązania: menu główne %d nie zdefiniowano"
+msgstr "przypisanie klawisza: nie zdefiniowano menu głównego \"%s\""
 
 #: src/client.c:903
 msgid "Kill this window?"
@@ -84,56 +85,55 @@ msgid "exec failed: (%s) %s"
 msgstr "exec nie powiodło się: (%s) %s"
 
 #: src/command.c:155
-#, fuzzy
 msgid "could not create pipe"
-msgstr "nie można załadować czcionki: %s"
+msgstr "nie można utworzyć połączenia"
 
 #: src/command.c:161
 msgid "could not set O_NONBLOCK"
-msgstr ""
+msgstr "nie można ustawić O_NONBLOCK"
 
 #: src/command.c:211
 #, c-format
 msgid "timeout: %s did not complete in %u milliseconds"
-msgstr ""
+msgstr "przekoroczono czas: %s nie skończył się w %u milisekund"
 
 #: src/confirm.c:69
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: src/confirm.c:74
 msgid "Cancel"
-msgstr ""
+msgstr "Anuluj"
 
 #: src/confirm.c:308
 msgid "Confirm"
-msgstr ""
+msgstr "Potwierdź"
 
 #: src/desktop.c:336
 msgid "empty Desktops Name tag"
-msgstr "pusty znacznik Nazwa Pulpitów"
+msgstr "pusty znacznik nazwy pulpitów"
 
 #: src/dock.c:151
 msgid "only one Dock allowed"
-msgstr "tylko jeden dozwolony Dock"
+msgstr "tylko jeden dozwolony dock"
 
 #: src/dock.c:232
 msgid "could not acquire system tray selection"
-msgstr "nie można nabyć wyboru w zasobniku systemowym"
+msgstr "nie można dostać wyboru w zasobniku systemowym"
 
 #: src/error.c:22
 #, c-format
 msgid "JWM: error: "
-msgstr ""
+msgstr "JWM: błąd: "
 
 #: src/error.c:51
 #, c-format
 msgid "JWM: warning: "
-msgstr ""
+msgstr "JWM: ostrzeżenie: "
 
 #: src/error.c:77
 msgid "display is already managed"
-msgstr ""
+msgstr "ekran jest już zarządzany"
 
 #: src/font.c:138 src/font.c:174
 #, c-format
@@ -158,31 +158,27 @@ msgid "invalid group name"
 msgstr "nieprawidłowa nazwa grupy"
 
 #: src/group.c:139
-#, fuzzy
-#| msgid "invalid group name"
 msgid "invalid group type"
-msgstr "nieprawidłowa nazwa grupy"
+msgstr "nieprawidłowy typ grupy"
 
 #: src/group.c:150
-#, fuzzy
-#| msgid "invalid group name"
 msgid "invalid group machine"
-msgstr "nieprawidłowa nazwa grupy"
+msgstr "nieprawidłowa maszyna grupy"
 
 #: src/group.c:343
 #, c-format
 msgid "invalid group desktop: %d"
-msgstr "nieprawidłowy pulpitu grupy: %d"
+msgstr "nieprawidłowy pulpit grupy: %d"
 
 #: src/image.c:147
 #, c-format
 msgid "unrecognized extension for \"%s\", expected \"%s\""
-msgstr ""
+msgstr "nierozpoznane rozszerzenie dla \"%s\", oczekiwane \"%s\""
 
 #: src/image.c:234
 #, c-format
 msgid "could not create read struct for PNG image: %s"
-msgstr "nie można utworzyć przeczytać struct dla obrazu PNG: %s"
+msgstr "nie można utworzyć struktury read dla obrazu PNG: %s"
 
 #: src/image.c:247
 #, c-format
@@ -197,7 +193,7 @@ msgstr "nie można utworzyć struktur informacji dla obrazu PNG: %s"
 #: src/lex.c:201
 #, c-format
 msgid "%s[%u]: close tag \"%s\" does not match open tag \"%s\""
-msgstr "%s[%u]: zamknij znacznik \"%s\" nie pasuje otwarty znacznik \"%s\""
+msgstr "%s[%u]: znacznik zamknięcia \"%s\" nie pasuje do znacznika otwarcia \"%s\""
 
 #: src/lex.c:207
 #, c-format
@@ -232,130 +228,127 @@ msgstr "%s[%u]: nieoczekiwany tekst: \"%s\""
 #: src/lex.c:397
 #, c-format
 msgid "%s[%d]: invalid entity: \"%.8s\""
-msgstr "%s[%d]: nieprawidłowa jednostka: \"%.8s\""
+msgstr "%s[%d]: nieprawidłowa wartość: \"%.8s\""
 
 #: src/lex.c:503
 msgid "out of memory"
-msgstr ""
+msgstr "brak pamięci"
 
 #: src/parse.c:272
-#, fuzzy, c-format
+#, c-format
 msgid "could not open %s"
-msgstr "nie można załadować czcionki: %s"
+msgstr "nie można otworzyć %s"
 
 #: src/parse.c:282
-#, fuzzy, c-format
+#, c-format
 msgid "could not open %s or %s"
-msgstr "nie można załadować czcionki: %s"
+msgstr "nie można otworzyć %s lub %s"
 
 #: src/parse.c:301
 #, c-format
 msgid "include depth (%d) exceeded"
-msgstr ""
+msgstr "przekroczono głębokość załączenia (%d)"
 
 #: src/parse.c:445
-#, fuzzy, c-format
+#, c-format
 msgid "invalid start tag: %s"
-msgstr "nieprawidłowy znacznik w: %s"
+msgstr "nieprawidłowy znacznik startu: %s"
 
 #: src/parse.c:837
-#, fuzzy, c-format
+#, c-format
 msgid "invalid include: %s"
-msgstr "nieprawidłowa warstwa grupy: %s"
+msgstr "nieprawidłowy załącznik: %s"
 
 #: src/parse.c:923
-#, fuzzy
 msgid "no action specified for Key"
-msgstr "ani klucza ani keycode określony dla Key"
+msgstr "brak określonej akcji dla Key"
 
 #: src/parse.c:930
-#, fuzzy, c-format
+#, c-format
 msgid "invalid Key action: \"%s\""
-msgstr "nieprawidłowa akcja TrayButton: \"%s\""
+msgstr "nieprawidłowa akcja dla Key: \"%s\""
 
 #: src/parse.c:956
-#, fuzzy
 msgid "no action specified for Mouse"
-msgstr "ani klucza ani keycode określony dla Key"
+msgstr "brak określonej akcji dla Mouse"
 
 #: src/parse.c:961
-#, fuzzy, c-format
+#, c-format
 msgid "invalid Mouse action: \"%s\""
-msgstr "nieprawidłowa akcja TrayButton: \"%s\""
+msgstr "nieprawidłowa akcja Mouse: \"%s\""
 
 #: src/parse.c:967
-#, fuzzy, c-format
+#, c-format
 msgid "invalid Mouse context: \"%s\""
-msgstr "nieprawidłowa akcja TrayButton: \"%s\""
+msgstr "nieprawidłowy kontekst Mouse: \"%s\""
 
 #: src/parse.c:988
-#, fuzzy, c-format
+#, c-format
 msgid "invalid text alignment: \"%s\""
 msgstr "nieprawidłowe wypionowanie zasobnika: \"%s\""
 
 #: src/parse.c:1076
 msgid "no include file specified"
-msgstr ""
+msgstr "nie odkreślonu pliku do załączenia"
 
 #: src/parse.c:1087
-#, fuzzy, c-format
+#, c-format
 msgid "could not process include: %s"
-msgstr "nie można załadować czcionki: %s"
+msgstr "nie można przetworzyć załączonego: %s"
 
 #: src/parse.c:1091
-#, fuzzy, c-format
+#, c-format
 msgid "could not open included file: %s"
-msgstr "nie można załadować czcionki: %s"
+msgstr "nie można otworzyć załączonego pliku: %s"
 
 #: src/parse.c:1743
-#, fuzzy, c-format
+#, c-format
 msgid "invalid value for 'enabled': \"%s\""
-msgstr "nieprawidłowa akcja TrayButton: \"%s\""
+msgstr "nieprawidłowa wartość dla 'enabled': \"%s\""
 
 #: src/parse.c:1890
-#, fuzzy, c-format
+#, c-format
 msgid "invalid Group Option: %s"
-msgstr "nieprawidłowy pulpitu grupy: %d"
+msgstr "nieprawidłowa opcja grupy: %s"
 
 #: src/parse.c:1905
-#, fuzzy, c-format
+#, c-format
 msgid "invalid decorations: %s"
-msgstr "nieprawidłowa akcja TrayButton: \"%s\""
+msgstr "nieprawidłowe dekoracje: %s"
 
 #: src/parse.c:1967
 #, c-format
 msgid "%s is empty"
-msgstr ""
+msgstr "%s jest puste"
 
 #: src/parse.c:1974
-#, fuzzy, c-format
+#, c-format
 msgid "invalid %s: \"%s\""
-msgstr "nieprawidłowa akcja TrayButton: \"%s\""
+msgstr "nieprawidłowa %s: \"%s\""
 
 #: src/parse.c:1992
-#, fuzzy, c-format
+#, c-format
 msgid "invalid value for %s: \"%s\""
-msgstr "nieprawidłowy znacznik w %s: %s"
+msgstr "nieprawidłowa wartość dla %s: \"%s\""
 
 #: src/parse.c:2062 src/parse.c:2079 src/parse.c:2107
-#, fuzzy
 msgid "no value specified"
-msgstr "nie określono wartości dla tła"
+msgstr "nie określono wartości"
 
 #: src/parse.c:2067 src/parse.c:2084
 #, c-format
 msgid "invalid setting: %s"
-msgstr "nieprawidłowy znacznik w: %s"
+msgstr "nieprawidłowe ustawienie: %s"
 
 #: src/parse.c:2112
 #, c-format
 msgid "invalid opacity: %s"
-msgstr "nieprawidłowa nieprzezroczystość menu: %s"
+msgstr "nieprawidłowa nieprzezroczystość: %s"
 
 #: src/parse.c:2133
 #, c-format
 msgid "invalid layer: %s"
-msgstr "nieprawidłowa warstwa grupy: %s"
+msgstr "nieprawidłowa warstwa: %s"
 
 #: src/parse.c:2154
 #, c-format
@@ -377,7 +370,7 @@ msgstr "Zakończ JWM"
 
 #: src/root.c:224
 msgid "Are you sure?"
-msgstr "Czy jesteś pewien?"
+msgstr "Na pewno?"
 
 #: src/swallow.c:85
 msgid "cannot swallow a client with no name"
@@ -406,9 +399,9 @@ msgid "invalid maxwidth for TaskList: %s"
 msgstr "nieprawidłowa maksymalna szerokość TaskList: %s"
 
 #: src/taskbar.c:1018
-#, fuzzy, c-format
+#, c-format
 msgid "invalid height for TaskList: %s"
-msgstr "nieprawidłowa maksymalna szerokość TaskList: %s"
+msgstr "nieprawidłowa wysokość TaskList: %s"
 
 #: src/tray.c:1082
 #, c-format
@@ -480,11 +473,11 @@ msgstr "Warstwa"
 
 #: src/winmenu.c:148
 msgid "[Above]"
-msgstr ""
+msgstr "[Powyżej]"
 
 #: src/winmenu.c:150
 msgid "Above"
-msgstr ""
+msgstr "Powyżej"
 
 #: src/winmenu.c:153
 msgid "[Normal]"
@@ -496,11 +489,11 @@ msgstr "Normalny"
 
 #: src/winmenu.c:158
 msgid "[Below]"
-msgstr ""
+msgstr "[Poniżej]"
 
 #: src/winmenu.c:160
 msgid "Below"
-msgstr ""
+msgstr "Poniżej"
 
 #~ msgid "invalid tray width: %d"
 #~ msgstr "nieprawidłowa szerokość zasobnika: %d"
@@ -515,7 +508,7 @@ msgstr ""
 #~ msgstr "nieprawidłowy typ tła: %s"
 
 #~ msgid "cannot swallow the same client multiple times"
-#~ msgstr "nie można połknąć tego samego klienta, wiele razy"
+#~ msgstr "nie można połknąć tego samego klienta wiele razy"
 
 #~ msgid "Fullscreen state will be shaped!"
 #~ msgstr "Pełnoekranowy stan będzie kształtowany!"


### PR DESCRIPTION
Add missing translations, replace fuzzy translations with proper ones and hopefully fix some mistakes.

Largely untested, as I currently don't have JWM installed anywhere, but hopefully it should work fine – there were no issues found when pasted to a PO editor.

I was thinking of changing plural forms to `"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"` but I decided not to overcomplicate it, especially as I don't know if plurals are used anywhere anyway. I just moved the line break a little higher after suggestion of Poedit.