### PR TITLE
Add window focus in number position in the taskbar

### DIFF
--- a/jwm.1.in
+++ b/jwm.1.in
@@ -1707,6 +1707,8 @@ Remove the current binding.
 Move to the previous window in the task list.
 .IP \fBprevstacked\fP
 Move to the previous window in the stacking order.
+.IP \fBat#\fP
+Move to window position in the task list.
 .IP \fBclose\fP
 Close the active window.
 .IP \fBminimize\fP

--- a/src/action.h
+++ b/src/action.h
@@ -64,6 +64,7 @@ typedef struct {
 #define ACTION_MAXH           41
 #define ACTION_RESTORE        42
 #define ACTION_CENTER         43
+#define ACTION_AT             44
 #define ACTION_INVALID        255
 #define ACTION_RESIZE_N       1  /* Extra value mask for resize north. */
 #define ACTION_RESIZE_S       2  /* Extra value mask for resize south. */

--- a/src/binding.c
+++ b/src/binding.c
@@ -306,6 +306,7 @@ char ShouldGrab(ActionType action)
    case ACTION_MAXH:
    case ACTION_RESTORE:
    case ACTION_CENTER:
+   case ACTION_AT:
       return 1;
    default:
       return 0;

--- a/src/event.c
+++ b/src/event.c
@@ -705,6 +705,10 @@ void ProcessBinding(MouseContextType context, ClientNode *np,
          RequirePagerUpdate();
       }
       break;
+    case ACTION_AT:
+      StartWindowWalk();
+      FocusAt(key.extra);
+      break;
    default:
       break;
    }

--- a/src/parse.c
+++ b/src/parse.c
@@ -43,6 +43,7 @@
  * Note that this mapping must be sorted.
  */
 static const StringMappingType ACTION_MAP[] = {
+   { "at#",                   ACTION_AT            },
    { "center",                ACTION_CENTER        },
    { "close",                 ACTION_CLOSE         },
    { "ddesktop",              ACTION_DDESKTOP      },

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -937,6 +937,23 @@ ClientFound:
    }
 }
 
+/** Focus the client in the task bar. */
+void FocusAt(char n)
+{
+   TaskEntry *tp;
+   char window = 0;
+      
+   for(tp = taskEntries; tp; tp = tp->next) {
+       if(ShouldFocusEntry(tp)) {
+          if(window == n) {
+             FocusGroup(tp);
+             break;
+          }
+          ++window;
+       }
+   }
+}
+
 /** Determine if there is anything to show for the specified entry. */
 char ShouldShowEntry(const TaskEntry *tp)
 {

--- a/src/taskbar.h
+++ b/src/taskbar.h
@@ -36,6 +36,11 @@ void RemoveClientFromTaskBar(struct ClientNode *np);
 /** Update all task bars. */
 void UpdateTaskBar(void);
 
+/** Focus the client in the task bar.
+ * @param n The window position in the taskbar.
+ */
+void FocusAt(char n);
+
 /** Focus the next client in the task bar. */
 void FocusNext(void);
 


### PR DESCRIPTION
Adds a window focus switch to the specified taskbar position using hotkeys. Example jwmrc:
```
<Key mask="4"  key="#">at#</Key>
```