### PR TITLE
Add new button label positions along with new vertical tasklist mode when labelpos is set to top or bottom

### DIFF
--- a/jwm.1.in
+++ b/jwm.1.in
@@ -687,6 +687,14 @@ Determines if a label is shown for items in the task list.
 The default is true.
 .RE
 .P
+\fBlabelpos\fP \fIstring\fP
+.RS
+Determines the label position in the task list. The default is "right" where
+the icon is on the left and the label is on the right.
+Possible values are "right", "top" and "bottom". When the tray is vertical and "top"
+or "bottom" is chosen, an alternate method for resizing the task list will be used.
+.RE
+.P
 \fBmaxwidth\fP \fIint\fP
 .RS
 The maximum width of an item in the task list. 0 indicates no maximum.

--- a/src/button.c
+++ b/src/button.c
@@ -96,8 +96,10 @@ static void GetButtonIconSize(ButtonNode *bp, int *width, int *height, int *icon
 
    if(bp->text) {
       if(bp->labelPos > LABEL_POSITION_RIGHT) {
+         /* Make room for the text. */
          maxIconHeight -= GetStringHeight(bp->font) + BUTTON_BORDER;
       } else {
+         /* Showing text, keep the icon square. */
          maxIconWidth = Min(*width, *height) - BUTTON_BORDER * 2;
       }
    }

--- a/src/button.c
+++ b/src/button.c
@@ -220,6 +220,7 @@ void DrawButton(ButtonNode *bp)
          xoffset = BUTTON_BORDER;
       }
 
+      /* Display the icon. */
       if(bp->icon) {
          yoffset = (height - iconHeight + 1) / 2;
          PutIcon(bp->icon, drawable, colors[fg],
@@ -250,6 +251,7 @@ void DrawButton(ButtonNode *bp)
          yoffset += textHeight + BUTTON_BORDER;
       }
 
+      /* Display the icon. */
       if(bp->icon) {
          xoffset = (width - iconWidth + 1) / 2;
          PutIcon(bp->icon, drawable, colors[fg],
@@ -260,6 +262,7 @@ void DrawButton(ButtonNode *bp)
       const int ycenter = (height - iconHeight - textHeight - BUTTON_BORDER + 1) / 2;
       yoffset = width <= height ? Max(BUTTON_BORDER, ycenter) : BUTTON_BORDER;
 
+      /* Display the icon. */
       if(bp->icon) {
          xoffset = (width - iconWidth + 1) / 2;
          PutIcon(bp->icon, drawable, colors[fg],

--- a/src/button.c
+++ b/src/button.c
@@ -149,16 +149,18 @@ void DrawButton(ButtonNode *bp)
    long bg1, bg2;
    long up, down;
    DecorationsType decorations;
-   
+
    Drawable drawable;
    GC gc;
    int x, y;
    int width, height;
    int xoffset, yoffset;
+
    int iconWidth, iconHeight;
    int textWidth, textHeight;
 
    Assert(bp);
+
    drawable = bp->drawable;
    x = bp->x;
    y = bp->y;

--- a/src/button.c
+++ b/src/button.c
@@ -221,6 +221,7 @@ void DrawButton(ButtonNode *bp)
       }
 
       if(bp->icon) {
+         yoffset = (height - iconHeight + 1) / 2;
          PutIcon(bp->icon, drawable, colors[fg],
                  x + xoffset, y + yoffset,
                  iconWidth, iconHeight);

--- a/src/button.c
+++ b/src/button.c
@@ -16,6 +16,98 @@
 #include "misc.h"
 #include "settings.h"
 
+static void GetButtonColors(ButtonNode *bp, ColorType *fg, long *bg1, long *bg2,
+                            long *up, long *down, DecorationsType *decorations)
+{
+   switch(bp->type) {
+   case BUTTON_LABEL:
+      *fg = COLOR_MENU_FG;
+      *bg1 = colors[COLOR_MENU_BG];
+      *bg2 = colors[COLOR_MENU_BG];
+      *up = colors[COLOR_MENU_UP];
+      *down = colors[COLOR_MENU_DOWN];
+      *decorations = settings.menuDecorations;
+      break;
+   case BUTTON_MENU_ACTIVE:
+      *fg = COLOR_MENU_ACTIVE_FG;
+      *bg1 = colors[COLOR_MENU_ACTIVE_BG1];
+      *bg2 = colors[COLOR_MENU_ACTIVE_BG2];
+      *down = colors[COLOR_MENU_ACTIVE_UP];
+      *up = colors[COLOR_MENU_ACTIVE_DOWN];
+      *decorations = settings.menuDecorations;
+      break;
+   case BUTTON_TRAY:
+      *fg = COLOR_TRAYBUTTON_FG;
+      *bg1 = colors[COLOR_TRAYBUTTON_BG1];
+      *bg2 = colors[COLOR_TRAYBUTTON_BG2];
+      *up = colors[COLOR_TRAYBUTTON_UP];
+      *down = colors[COLOR_TRAYBUTTON_DOWN];
+      *decorations = settings.trayDecorations;
+      break;
+   case BUTTON_TRAY_ACTIVE:
+      *fg = COLOR_TRAYBUTTON_ACTIVE_FG;
+      *bg1 = colors[COLOR_TRAYBUTTON_ACTIVE_BG1];
+      *bg2 = colors[COLOR_TRAYBUTTON_ACTIVE_BG2];
+      *down = colors[COLOR_TRAYBUTTON_ACTIVE_UP];
+      *up = colors[COLOR_TRAYBUTTON_ACTIVE_DOWN];
+      *decorations = settings.trayDecorations;
+      break;
+   case BUTTON_TASK:
+      *fg = COLOR_TASKLIST_FG;
+      *bg1 = colors[COLOR_TASKLIST_BG1];
+      *bg2 = colors[COLOR_TASKLIST_BG2];
+      *up = colors[COLOR_TASKLIST_UP];
+      *down = colors[COLOR_TASKLIST_DOWN];
+      *decorations = settings.taskListDecorations;
+      break;
+   case BUTTON_TASK_ACTIVE:
+      *fg = COLOR_TASKLIST_ACTIVE_FG;
+      *bg1 = colors[COLOR_TASKLIST_ACTIVE_BG1];
+      *bg2 = colors[COLOR_TASKLIST_ACTIVE_BG2];
+      *down = colors[COLOR_TASKLIST_ACTIVE_UP];
+      *up = colors[COLOR_TASKLIST_ACTIVE_DOWN];
+      *decorations = settings.taskListDecorations;
+      break;
+   case BUTTON_MENU:
+   default:
+      *fg = COLOR_MENU_FG;
+      *bg1 = colors[COLOR_MENU_BG];
+      *bg2 = colors[COLOR_MENU_BG];
+      *up = colors[COLOR_MENU_UP];
+      *down = colors[COLOR_MENU_DOWN];
+      *decorations = settings.menuDecorations;
+      break;
+   }
+
+}
+
+/* Determine the size of the icon (if any) to display. */
+static void GetButtonIconSize(ButtonNode *bp, int *width, int *height, int *iconWidth, int *iconHeight)
+{
+   *iconWidth = 0;
+   *iconHeight = 0;
+   if(bp->icon) {
+      if(!bp->icon->width || !bp->icon->height) {
+         *iconWidth = Min(*width - BUTTON_BORDER * 2, *height - BUTTON_BORDER * 2);
+         *iconHeight = *iconWidth;
+      } else {
+         const int ratio = (bp->icon->width << 16) / bp->icon->height;
+         int maxIconWidth = *width - BUTTON_BORDER * 2;
+         if(bp->text) {
+            /* Showing text, keep the icon square. */
+            maxIconWidth = Min(*width, *height) - BUTTON_BORDER * 2;
+         }
+         *iconHeight = *height - BUTTON_BORDER * 2;
+         *iconWidth = (*iconHeight * ratio) >> 16;
+         if(*iconWidth > maxIconWidth) {
+            *iconWidth = maxIconWidth;
+            *iconHeight = (*iconWidth << 16) / ratio;
+         }
+      }
+   }
+
+}
+
 /** Draw a button. */
 void DrawButton(ButtonNode *bp)
 {
@@ -44,65 +136,7 @@ void DrawButton(ButtonNode *bp)
    gc = JXCreateGC(display, drawable, 0, NULL);
 
    /* Determine the colors to use. */
-   switch(bp->type) {
-   case BUTTON_LABEL:
-      fg = COLOR_MENU_FG;
-      bg1 = colors[COLOR_MENU_BG];
-      bg2 = colors[COLOR_MENU_BG];
-      up = colors[COLOR_MENU_UP];
-      down = colors[COLOR_MENU_DOWN];
-      decorations = settings.menuDecorations;
-      break;
-   case BUTTON_MENU_ACTIVE:
-      fg = COLOR_MENU_ACTIVE_FG;
-      bg1 = colors[COLOR_MENU_ACTIVE_BG1];
-      bg2 = colors[COLOR_MENU_ACTIVE_BG2];
-      down = colors[COLOR_MENU_ACTIVE_UP];
-      up = colors[COLOR_MENU_ACTIVE_DOWN];
-      decorations = settings.menuDecorations;
-      break;
-   case BUTTON_TRAY:
-      fg = COLOR_TRAYBUTTON_FG;
-      bg1 = colors[COLOR_TRAYBUTTON_BG1];
-      bg2 = colors[COLOR_TRAYBUTTON_BG2];
-      up = colors[COLOR_TRAYBUTTON_UP];
-      down = colors[COLOR_TRAYBUTTON_DOWN];
-      decorations = settings.trayDecorations;
-      break;
-   case BUTTON_TRAY_ACTIVE:
-      fg = COLOR_TRAYBUTTON_ACTIVE_FG;
-      bg1 = colors[COLOR_TRAYBUTTON_ACTIVE_BG1];
-      bg2 = colors[COLOR_TRAYBUTTON_ACTIVE_BG2];
-      down = colors[COLOR_TRAYBUTTON_ACTIVE_UP];
-      up = colors[COLOR_TRAYBUTTON_ACTIVE_DOWN];
-      decorations = settings.trayDecorations;
-      break;
-   case BUTTON_TASK:
-      fg = COLOR_TASKLIST_FG;
-      bg1 = colors[COLOR_TASKLIST_BG1];
-      bg2 = colors[COLOR_TASKLIST_BG2];
-      up = colors[COLOR_TASKLIST_UP];
-      down = colors[COLOR_TASKLIST_DOWN];
-      decorations = settings.taskListDecorations;
-      break;
-   case BUTTON_TASK_ACTIVE:
-      fg = COLOR_TASKLIST_ACTIVE_FG;
-      bg1 = colors[COLOR_TASKLIST_ACTIVE_BG1];
-      bg2 = colors[COLOR_TASKLIST_ACTIVE_BG2];
-      down = colors[COLOR_TASKLIST_ACTIVE_UP];
-      up = colors[COLOR_TASKLIST_ACTIVE_DOWN];
-      decorations = settings.taskListDecorations;
-      break;
-   case BUTTON_MENU:
-   default:
-      fg = COLOR_MENU_FG;
-      bg1 = colors[COLOR_MENU_BG];
-      bg2 = colors[COLOR_MENU_BG];
-      up = colors[COLOR_MENU_UP];
-      down = colors[COLOR_MENU_DOWN];
-      decorations = settings.menuDecorations;
-      break;
-   }
+   GetButtonColors(bp, &fg, &bg1, &bg2, &up, &down, &decorations);
 
    /* Draw the background. */
    if(bp->fill) {
@@ -138,27 +172,7 @@ void DrawButton(ButtonNode *bp)
    }
 
    /* Determine the size of the icon (if any) to display. */
-   iconWidth = 0;
-   iconHeight = 0;
-   if(bp->icon) {
-      if(!bp->icon->width || !bp->icon->height) {
-         iconWidth = Min(width - BUTTON_BORDER * 2, height - BUTTON_BORDER * 2);
-         iconHeight = iconWidth;
-      } else {
-         const int ratio = (bp->icon->width << 16) / bp->icon->height;
-         int maxIconWidth = width - BUTTON_BORDER * 2;
-         if(bp->text) {
-            /* Showing text, keep the icon square. */
-            maxIconWidth = Min(width, height) - BUTTON_BORDER * 2;
-         }
-         iconHeight = height - BUTTON_BORDER * 2;
-         iconWidth = (iconHeight * ratio) >> 16;
-         if(iconWidth > maxIconWidth) {
-            iconWidth = maxIconWidth;
-            iconHeight = (iconWidth << 16) / ratio;
-         }
-      }
-   }
+   GetButtonIconSize(bp, &width, &height, &iconWidth, &iconHeight);
 
    /* Determine how much room is left for text. */
    textWidth = 0;
@@ -198,6 +212,106 @@ void DrawButton(ButtonNode *bp)
       RenderString(drawable, bp->font, fg,
                    x + xoffset, y + yoffset,
                    textWidth, bp->text);
+   }
+
+   JXFreeGC(display, gc);
+
+}
+
+void DrawButtonVertical(ButtonNode *bp)
+{
+   ColorType fg;
+   long bg1, bg2;
+   long up, down;
+   DecorationsType decorations;
+   
+   Drawable drawable;
+   GC gc;
+   int x, y;
+   int width, height;
+   int xoffset, yoffset;
+   int iconWidth, iconHeight;
+   int textWidth, textHeight;
+
+   Assert(bp);
+   drawable = bp->drawable;
+   x = bp->x;
+   y = bp->y;
+   width = bp->width;
+   height = bp->height;
+   gc = JXCreateGC(display, drawable, 0, NULL);
+
+   /* Determine the colors to use. */
+   GetButtonColors(bp, &fg, &bg1, &bg2, &up, &down, &decorations);
+
+   /* Draw the background. */
+   if(bp->fill) {
+
+      /* Draw the button background. */
+      JXSetForeground(display, gc, bg1);
+      if(bg1 == bg2) {
+         /* single color */
+         JXFillRectangle(display, drawable, gc, x, y, width, height);
+      } else {
+         /* gradient */
+         DrawHorizontalGradient(drawable, gc, bg1, bg2,
+                                x, y, width, height);
+      }
+
+   }
+
+   /* Draw the border. */
+   if(bp->border) {
+      if(decorations == DECO_MOTIF) {
+         JXSetForeground(display, gc, up);
+         JXDrawLine(display, drawable, gc, x, y, x + width - 1, y);
+         JXDrawLine(display, drawable, gc, x, y, x, y + height - 1);
+         JXSetForeground(display, gc, down);
+         JXDrawLine(display, drawable, gc, x, y + height - 1,
+                    x + width - 1, y + height - 1);
+         JXDrawLine(display, drawable, gc, x + width - 1, y,
+                    x + width - 1, y + height - 1);
+      } else {
+         JXSetForeground(display, gc, down);
+         JXDrawRectangle(display, drawable, gc, x, y, width - 1, height - 1);
+      }
+   }
+
+   /* Determine the size of the icon (if any) to display. */
+   GetButtonIconSize(bp, &width, &height, &iconWidth, &iconHeight);
+
+   /* Determine how much room is left for text. */
+   textWidth = 0;
+   textHeight = 0;
+   if(bp->text) {
+        textWidth = GetStringWidth(bp->font, bp->text);
+        textHeight = GetStringHeight(bp->font);
+        if(textHeight + iconHeight + BUTTON_BORDER * 3 > height) {
+            textHeight = height - iconHeight - BUTTON_BORDER * 3;
+        }
+   }
+
+   /* Determine the offset of the icon in the button. */
+   xoffset = (width - iconWidth + 1) / 2;
+   yoffset = BUTTON_BORDER;
+
+   /* Display the icon. */
+   if(bp->icon) {
+      PutIcon(bp->icon, drawable, colors[fg],
+            x + xoffset, y + yoffset,
+            iconWidth, iconHeight);
+      yoffset += iconHeight + BUTTON_BORDER;
+   }
+
+   if(textHeight > 0) {
+      if(textWidth <= iconWidth) {
+         xoffset = (width - textWidth + 1) / 2;
+      } else {
+         xoffset = BUTTON_BORDER;
+      }
+      RenderString(drawable, bp->font, fg,
+                  x + xoffset, y + yoffset,
+               textWidth, bp->text);
    }
 
    JXFreeGC(display, gc);

--- a/src/button.c
+++ b/src/button.c
@@ -232,8 +232,8 @@ void DrawButton(ButtonNode *bp)
       if(textWidth > 0) {
          yoffset = (height - textHeight + 1) / 2;
          RenderString(drawable, bp->font, fg,
-                     x + xoffset, y + yoffset,
-                 textWidth, bp->text);
+                      x + xoffset, y + yoffset,
+                      textWidth, bp->text);
       }
    } else if (bp->labelPos == LABEL_POSITION_TOP) {
       const int ycenter = (height - textHeight - iconHeight - BUTTON_BORDER + 1) / 2;
@@ -245,26 +245,26 @@ void DrawButton(ButtonNode *bp)
          yoffset = width <= height ? Max(BUTTON_BORDER, ycenter) : BUTTON_BORDER;
 
          RenderString(drawable, bp->font, fg,
-                    x + xoffset, y + yoffset,
-                textWidth, bp->text);
+                      x + xoffset, y + yoffset,
+                      textWidth, bp->text);
          yoffset += textHeight + BUTTON_BORDER;
       }
 
       if(bp->icon) {
          xoffset = (width - iconWidth + 1) / 2;
          PutIcon(bp->icon, drawable, colors[fg],
-               x + xoffset, y + yoffset,
-           iconWidth, iconHeight);
+                 x + xoffset, y + yoffset,
+                 iconWidth, iconHeight);
       }
    } else if (bp->labelPos == LABEL_POSITION_BOTTOM) {
       const int ycenter = (height - iconHeight - textHeight - BUTTON_BORDER + 1) / 2;
-      xoffset = (width - iconWidth + 1) / 2;
       yoffset = width <= height ? Max(BUTTON_BORDER, ycenter) : BUTTON_BORDER;
 
       if(bp->icon) {
+         xoffset = (width - iconWidth + 1) / 2;
          PutIcon(bp->icon, drawable, colors[fg],
-               x + xoffset, y + yoffset,
-               iconWidth, iconHeight);
+                 x + xoffset, y + yoffset,
+                 iconWidth, iconHeight);
          yoffset += iconHeight + BUTTON_BORDER;
       }
 
@@ -272,8 +272,8 @@ void DrawButton(ButtonNode *bp)
       if(textHeight > 0 && textWidth > 0) {
          xoffset = (width - textWidth + 1) / 2;
          RenderString(drawable, bp->font, fg,
-                     x + xoffset, y + yoffset,
-                  textWidth, bp->text);
+                      x + xoffset, y + yoffset,
+                      textWidth, bp->text);
       }
    }
 

--- a/src/button.h
+++ b/src/button.h
@@ -52,6 +52,11 @@ typedef struct {
  */
 void DrawButton(ButtonNode *bp);
 
+/** Draw a vertical button.
+ * @param bp The button to draw
+ */
+void DrawButtonVertical(ButtonNode *bp);
+
 /** Reset the contents of a ButtonNode structure.
  * @param bp The structure to reset.
  * @param d The drawable to use.

--- a/src/button.h
+++ b/src/button.h
@@ -28,11 +28,18 @@ typedef unsigned char ButtonType;
 #define BUTTON_TASK        5  /**< Item in the task list. */
 #define BUTTON_TASK_ACTIVE 6  /**< Active item in the task list. */
 
+/** Enumeration of button label positions. */
+typedef unsigned char LabelPosition;
+#define LABEL_POSITION_RIGHT  0  /**< Right of the button icon. */
+#define LABEL_POSITION_TOP    1  /**< Above of the button icon. */
+#define LABEL_POSITION_BOTTOM 2  /**< Below the button icon.. */
+
 /** Data used for drawing a button. */
 typedef struct {
 
    ButtonType type;           /**< The type of button to draw. */
    AlignmentType alignment;   /**< Alignment of the button content. */
+   LabelPosition labelPos;    /**< Position of the button label. */
    FontType font;             /**< The font for button text. */
    char fill;                 /**< Determine if we should fill. */
    char border;               /**< Determine if we should draw a border. */
@@ -51,11 +58,6 @@ typedef struct {
  * @param bp The button to draw.
  */
 void DrawButton(ButtonNode *bp);
-
-/** Draw a vertical button.
- * @param bp The button to draw
- */
-void DrawButtonVertical(ButtonNode *bp);
 
 /** Reset the contents of a ButtonNode structure.
  * @param bp The structure to reset.

--- a/src/menu.c
+++ b/src/menu.c
@@ -853,6 +853,7 @@ void DrawMenuItem(Menu *menu, MenuItem *item, int index)
          button.type = BUTTON_LABEL;
          button.text = menu->label;
          button.alignment = ALIGN_CENTER;
+         button.labelPos = LABEL_POSITION_RIGHT;
          DrawButton(&button);
       }
       return;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1220,6 +1220,11 @@ void ParseTrayStyle(const TokenNode *tp, FontType font, ColorType fg)
          settings.listAllTasks = !strcmp(temp, "all");
       }
 
+      temp = FindAttribute(tp->attributes, "altvertlist");
+      if(temp) {
+         settings.altVerticalTasks = !strcmp(temp, TRUE_VALUE);
+      }
+
       temp = FindAttribute(tp->attributes, KILL_MENU_ATTRIBUTE);
       if(temp) {
          settings.showKillMenuItem = !strcmp(temp, TRUE_VALUE);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1220,11 +1220,6 @@ void ParseTrayStyle(const TokenNode *tp, FontType font, ColorType fg)
          settings.listAllTasks = !strcmp(temp, "all");
       }
 
-      temp = FindAttribute(tp->attributes, "altvertlist");
-      if(temp) {
-         settings.altVerticalTasks = !strcmp(temp, TRUE_VALUE);
-      }
-
       temp = FindAttribute(tp->attributes, KILL_MENU_ATTRIBUTE);
       if(temp) {
          settings.showKillMenuItem = !strcmp(temp, TRUE_VALUE);
@@ -1444,6 +1439,12 @@ void ParseTaskList(const TokenNode *tp, TrayType *tray)
    if(temp && !strcmp(temp, FALSE_VALUE)) {
       SetTaskBarLabeled(cp, 0);
    }
+
+   temp = FindAttribute(tp->attributes, "labelpos");
+   if(temp) {
+      SetTaskBarLabelPosition(cp, temp);
+   }
+
 }
 
 /** Parse the tray button style. */

--- a/src/settings.h
+++ b/src/settings.h
@@ -123,6 +123,7 @@ typedef struct {
    MouseContextType titleBarLayout[TBC_COUNT + 1];
    char groupTasks;
    char listAllTasks;
+   char altVerticalTasks;
    char showClientName;
    char clientNameDelimiters[2];
    char showKillMenuItem;

--- a/src/settings.h
+++ b/src/settings.h
@@ -123,7 +123,6 @@ typedef struct {
    MouseContextType titleBarLayout[TBC_COUNT + 1];
    char groupTasks;
    char listAllTasks;
-   char altVerticalTasks;
    char showClientName;
    char clientNameDelimiters[2];
    char showKillMenuItem;

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -864,7 +864,6 @@ void Render(const TaskBarType *bp)
             button.text = tp->clients->client->name;
          }
       }
-
       DrawButton(&button);
 
       if(displayName) {

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -192,14 +192,37 @@ void ComputeItemSize(TaskBarType *tp)
 {
    TrayComponentType *cp = tp->cp;
    if(tp->layout == LAYOUT_VERTICAL) {
+      TaskEntry *ep;
+      unsigned itemCount = 0;
 
+      tp->itemWidth = cp->width;
+      for(ep = taskEntries; ep; ep = ep->next) {
+         if(ShouldShowEntry(ep)) {
+            itemCount += 1;
+         }
+      }
+      if(itemCount == 0) {
+         return;
+      }
+
+      tp->itemHeight = Max(1, cp->height / itemCount);
+      if(!tp->labeled) {
+         tp->itemHeight = Min(tp->itemWidth, tp->itemHeight);
+      } else {
+         tp->itemHeight = Min(tp->itemWidth + GetStringHeight(FONT_TASKLIST), tp->itemHeight);
+      }
+
+      if(tp->maxItemWidth > 0) {
+         tp->itemHeight = Min(tp->maxItemWidth, tp->itemHeight);
+      }
+/*
       if(tp->userHeight > 0) {
          tp->itemHeight = tp->userHeight;
       } else {
          tp->itemHeight = GetStringHeight(FONT_TASKLIST) + 12;
       }
       tp->itemWidth = cp->width;
-
+*/
    } else {
 
       TaskEntry *ep;
@@ -713,7 +736,7 @@ void UpdateTaskBar(void)
    }
 
    for(bp = bars; bp; bp = bp->next) {
-      if(bp->layout == LAYOUT_VERTICAL) {
+/*      if(bp->layout == LAYOUT_VERTICAL) {
          TaskEntry *tp;
          lastHeight = bp->cp->requestedHeight;
          if(bp->userHeight > 0) {
@@ -732,6 +755,7 @@ void UpdateTaskBar(void)
             ResizeTray(bp->cp->tray);
          }
       }
+*/
       ComputeItemSize(bp);
       Render(bp);
    }
@@ -838,7 +862,13 @@ void Render(const TaskBarType *bp)
             button.text = tp->clients->client->name;
          }
       }
-      DrawButton(&button);
+
+      if(bp->layout == LAYOUT_HORIZONTAL) {
+         DrawButton(&button);
+      } else {
+         DrawButtonVertical(&button);
+      }
+
       if(displayName) {
          Release(displayName);
       }

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -38,6 +38,7 @@ typedef struct TaskBarType {
    int itemWidth;
    LayoutType layout;
    char labeled;
+   LabelPosition labelPos;
 
    Pixmap buffer;
 
@@ -129,6 +130,7 @@ TrayComponentType *CreateTaskBar()
    tp->maxItemWidth = 0;
    tp->layout = LAYOUT_HORIZONTAL;
    tp->labeled = 1;
+   tp->labelPos = LABEL_POSITION_RIGHT;
    tp->mousex = -settings.doubleClickDelta;
    tp->mousey = -settings.doubleClickDelta;
    tp->mouseTime.seconds = 0;
@@ -207,7 +209,7 @@ void ComputeItemSize(TaskBarType *tp)
    TrayComponentType *cp = tp->cp;
 
    if(tp->layout == LAYOUT_VERTICAL) {
-      if(settings.altVerticalTasks) {
+      if(tp->labelPos > LABEL_POSITION_RIGHT) {
          unsigned itemCount = TallyVisibleItems();
          if(itemCount == 0) {
             return;
@@ -736,7 +738,7 @@ void UpdateTaskBar(void)
    }
 
    for(bp = bars; bp; bp = bp->next) {
-      if(bp->layout == LAYOUT_VERTICAL && !settings.altVerticalTasks) {
+      if(bp->layout == LAYOUT_VERTICAL && bp->labelPos < LABEL_POSITION_TOP) {
          TaskEntry *tp;
          lastHeight = bp->cp->requestedHeight;
          if(bp->userHeight > 0) {
@@ -809,6 +811,7 @@ void Render(const TaskBarType *bp)
    button.font = FONT_TASKLIST;
    button.height = bp->itemHeight;
    button.width = bp->itemWidth;
+   button.labelPos = bp->labelPos;
    button.text = NULL;
 
    x = 0;
@@ -862,11 +865,7 @@ void Render(const TaskBarType *bp)
          }
       }
 
-      if(bp->layout == LAYOUT_HORIZONTAL || !settings.altVerticalTasks) {
-         DrawButton(&button);
-      } else {
-         DrawButtonVertical(&button);
-      }
+      DrawButton(&button);
 
       if(displayName) {
          Release(displayName);
@@ -1072,6 +1071,25 @@ void SetTaskBarLabeled(TrayComponentType *cp, char labeled)
 {
    TaskBarType *bp = (TaskBarType*)cp->object;
    bp->labeled = labeled;
+}
+
+/** Set the label's postion. */
+void SetTaskBarLabelPosition(TrayComponentType *cp, const char *value)
+{
+   TaskBarType *bp = (TaskBarType*)cp->object;
+
+   Assert(cp);
+   Assert(value);
+
+   if(!strcmp(value, "right")) {
+      bp->labelPos = LABEL_POSITION_RIGHT;
+   } else if(!strcmp(value, "top")) {
+      bp->labelPos = LABEL_POSITION_TOP;
+   } else if(!strcmp(value, "bottom")) {
+      bp->labelPos = LABEL_POSITION_BOTTOM;
+   } else {
+      Warning(_("invalid labelpos for TaskList: %s"), value);
+   }
 }
 
 /** Maintain the _NET_CLIENT_LIST[_STACKING] properties on the root. */

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -232,7 +232,7 @@ void ComputeItemSize(TaskBarType *tp)
    } else {
       unsigned itemCount = TallyVisibleItems();
       if(itemCount == 0) {
-            return;
+         return;
       }
 
       tp->itemHeight = cp->height;

--- a/src/taskbar.h
+++ b/src/taskbar.h
@@ -65,6 +65,12 @@ void SetTaskBarHeight(struct TrayComponentType *cp, const char *value);
  */
 void SetTaskBarLabeled(struct TrayComponentType *cp, char value);
 
+/** Set where labels should be positioned in relation to the icon.
+ * @param cp The task bar component.
+ * @param value 0 for right of the icon, 1 for above the icon, 2 for below the icon.
+ */
+void SetTaskBarLabelPosition(struct TrayComponentType *cp, const char *value);
+
 /** Update the _NET_CLIENT_LIST property. */
 void UpdateNetClientList(void);
 

--- a/src/traybutton.c
+++ b/src/traybutton.c
@@ -296,6 +296,7 @@ void Draw(TrayComponentType *cp)
    button.y = 0;
    button.font = FONT_TRAY;
    button.text = bp->label;
+   button.labelPos = LABEL_POSITION_RIGHT;
    button.icon = bp->icon;
    DrawButton(&button);
 


### PR DESCRIPTION
This is a WIP prototype of vertical buttons. They are now utilized for the tasklist when the tray is vertical. I'm not quite yet satisfied with it yet since there are still some issues with resizing and the text disappearing too early when the task icon is too big. But I plan to address those issues.

It will currently try to center the text if the text width is less than or equal to the icon width, otherwise, it will have the text on the left.

To avoid too many changes I just made another Button function that handles drawing instead of adding new logic to the existing DrawButton function. 

I did take out some of the existing logic that was in DrawButton and move them into their own functions but I only did that for some parts of it since the parts that use preprocessor macros didn't end up working for me.  So I just left them as is.

I posted my results in an existing issue over at https://github.com/joewing/jwm/issues/457
But I don't think too many people noticed it so I'm posting it here for further feedback/ideas.

![Screenshot_20240627_152205](https://github.com/joewing/jwm/assets/8182590/09ce6c50-3a02-47fb-99c8-3c5dae9f6589)

FYI: The User defined height attribute for the tasklist is ignored for now.