### PR TITLE
Fix sloppy focus issues around desktop windows (file managers, etc), fix uninitialized windowType

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -901,7 +901,7 @@ void HandleEnterNotify(const XCrossingEvent *event)
       if(  !(np->state.status & STAT_ACTIVE)
          && (settings.focusModel == FOCUS_SLOPPY
             || settings.focusModel == FOCUS_SLOPPY_TITLE)
-         && (np->state.layer != LAYER_DESKTOP)) {
+         && (np->state.windowType != WINDOW_TYPE_DESKTOP)) {
          FocusClient(np);
       }
       if(np->parent == event->window) {

--- a/src/event.c
+++ b/src/event.c
@@ -900,7 +900,8 @@ void HandleEnterNotify(const XCrossingEvent *event)
    if(np) {
       if(  !(np->state.status & STAT_ACTIVE)
          && (settings.focusModel == FOCUS_SLOPPY
-            || settings.focusModel == FOCUS_SLOPPY_TITLE)) {
+            || settings.focusModel == FOCUS_SLOPPY_TITLE)
+         && (np->state.layer != LAYER_DESKTOP)) {
          FocusClient(np);
       }
       if(np->parent == event->window) {

--- a/src/event.c
+++ b/src/event.c
@@ -84,6 +84,7 @@ static void HandleNetWMState(const XClientMessageEvent *event,
 static void HandleFrameExtentsRequest(const XClientMessageEvent *event);
 static void UpdateState(ClientNode *np);
 static void DiscardEnterEvents();
+static char ClientCanReceiveSloppyFocus(const ClientNode *np);
 
 #ifdef USE_SHAPE
 static void HandleShapeEvent(const XShapeEvent *event);
@@ -891,6 +892,29 @@ char HandleConfigureNotify(const XConfigureEvent *event)
    return 1;
 }
 
+/** True if a window should receive focus if the pointer moves over it. */
+char ClientCanReceiveSloppyFocus(const ClientNode *np)
+{
+   /* Not if the window is already active */
+   if(np->state.status & STAT_ACTIVE) {
+      return 0;
+   }
+   /* Only when running in a sloppy focus mode */
+   if(! (settings.focusModel == FOCUS_SLOPPY
+         || settings.focusModel == FOCUS_SLOPPY_TITLE)) {
+      return 0;
+   }
+   /* The user will probably understand desktop windows as a kind of
+    * empty space. If they took focus based just on mouse motion over
+    * them, sloppy focus would feel broken. They can still be given
+    * focus with a click. */
+   if((np->state.windowType == WINDOW_TYPE_DESKTOP)
+      || (np->state.layer == LAYER_DESKTOP)) {
+      return 0;
+   }
+   return 1;
+}
+
 /** Process an enter notify event. */
 void HandleEnterNotify(const XCrossingEvent *event)
 {
@@ -898,10 +922,7 @@ void HandleEnterNotify(const XCrossingEvent *event)
    Cursor cur;
    np = FindClient(event->window);
    if(np) {
-      if(  !(np->state.status & STAT_ACTIVE)
-         && (settings.focusModel == FOCUS_SLOPPY
-            || settings.focusModel == FOCUS_SLOPPY_TITLE)
-         && (np->state.windowType != WINDOW_TYPE_DESKTOP)) {
+      if(ClientCanReceiveSloppyFocus(np)) {
          FocusClient(np);
       }
       if(np->parent == event->window) {

--- a/src/hint.c
+++ b/src/hint.c
@@ -560,11 +560,13 @@ ClientState ReadWindowState(Window win, char alreadyMapped)
 
    Assert(win != None);
 
+   /* !! Keep in sync: defaults for ClientState in hint.h */
    result.status = STAT_MAPPED;
    result.maxFlags = MAX_NONE;
    result.border = BORDER_DEFAULT;
    result.layer = LAYER_NORMAL;
    result.defaultLayer = LAYER_NORMAL;
+   result.windowType = WINDOW_TYPE_NORMAL;
    result.desktop = currentDesktop;
    result.opacity = UINT_MAX;
 

--- a/src/hint.h
+++ b/src/hint.h
@@ -168,7 +168,7 @@ typedef struct ClientState {
    unsigned char layer;          /**< Current window layer. */
    unsigned char defaultLayer;   /**< Default window layer. */
    unsigned char windowType;     /**< Window type. */
-} ClientState;
+} ClientState;  /* !! Keep in sync: defaults go in ReadWindowState() */
 
 extern Atom atoms[ATOM_COUNT];
 

--- a/src/pager.c
+++ b/src/pager.c
@@ -550,7 +550,7 @@ void DrawPager(const PagerType *pp)
    /* Draw the clients. */
    for(x = FIRST_LAYER; x <= LAST_LAYER; x++) {
       for(np = nodeTail[x]; np; np = np->prev) {
-         if (np->state.layer != LAYER_DESKTOP) {
+         if (np->state.windowType != WINDOW_TYPE_DESKTOP) {
             DrawPagerClient(pp, np);
          }
       }

--- a/src/pager.c
+++ b/src/pager.c
@@ -550,9 +550,7 @@ void DrawPager(const PagerType *pp)
    /* Draw the clients. */
    for(x = FIRST_LAYER; x <= LAST_LAYER; x++) {
       for(np = nodeTail[x]; np; np = np->prev) {
-         if (np->state.windowType != WINDOW_TYPE_DESKTOP) {
-            DrawPagerClient(pp, np);
-         }
+         DrawPagerClient(pp, np);
       }
    }
 
@@ -626,6 +624,14 @@ void DrawPagerClient(const PagerType *pp, const ClientNode *np)
    if(!(np->state.status & STAT_MAPPED)) {
       return;
    }
+   /* The user will probably expect to see windows providing background
+    * images and/or desktop file icons as "unoccupied space", as if there
+    * were no non-root window there really. */
+   if((np->state.windowType == WINDOW_TYPE_DESKTOP) ||
+      (np->state.layer == LAYER_DESKTOP)) {
+      return;
+   }
+   /* Skip anything we're specifically told to skip too. */
    if(np->state.status & STAT_NOPAGER) {
       return;
    }

--- a/src/pager.c
+++ b/src/pager.c
@@ -550,7 +550,9 @@ void DrawPager(const PagerType *pp)
    /* Draw the clients. */
    for(x = FIRST_LAYER; x <= LAST_LAYER; x++) {
       for(np = nodeTail[x]; np; np = np->prev) {
-         DrawPagerClient(pp, np);
+         if (np->state.layer != LAYER_DESKTOP) {
+            DrawPagerClient(pp, np);
+         }
       }
    }
 


### PR DESCRIPTION
This combines two separate commits that fix some issues with background/desktop windows and JWM's sloppy focus.

The user probably considers background widows, like those provided by file managers, to be something other than a regular window, and might consider sloppy focus to be broken by them (see joewing/jwm#613). In point of fact, these windows should probably not receive sloppy focus; however they can still be usefully focussed and interacted with.

Therefore, require clicks before interaction even in sloppy focus mode.

They also may not appreciate a giant rectangle in the pager behind all the other ones. You can't usefully move one of these background filer windows, and it probably shouldn't hide the pager's desktop number either if the current desktop happens to be empty.