### PR TITLE
Add a minimal .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{jwmrc,xml,xslt}{,.in}]
+indent_style = space
+indent_size = 4
+
+[*.shtml{,.in}]
+indent_style = space
+indent_size = 1
+
+[*.{c,h}{,.in}]
+indent_style = space
+indent_size = 3
+
+[Makefile{,.in}]
+indent_style = tab
+indent_size = tab
+tab_width = 8


### PR DESCRIPTION
It's a minor thing, but editing is a little easier for me with a [`.editorconfig`](https://editorconfig.org/). Having this file may help contributors to conform to the project's coding conventions.

I hope I've covered most of the styles in use, and that they're correct.