### PR TITLE
Prevent shortcuts & buttons from bypassing 'nomin'

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -287,7 +287,7 @@ void ShowDesktop(void)
                   JXSetInputFocus(display, rootWindow, RevertToParent,
                                   CurrentTime);
                }
-               if(np->state.status & (STAT_MAPPED | STAT_SHADED)) {
+               if(np->state.status & (STAT_MAPPED | STAT_SHADED) && (np->state.border & BORDER_MIN)) {
                   MinimizeClient(np, 0);
                   np->state.status |= STAT_SDESKTOP;
                }

--- a/src/event.c
+++ b/src/event.c
@@ -584,7 +584,7 @@ void ProcessBinding(MouseContextType context, ClientNode *np,
       }
       break;
    case ACTION_MIN:
-      if(np) {
+      if(np && (np->state.border & BORDER_MIN)) {
          MinimizeClient(np, 1);
       }
       break;
@@ -601,7 +601,7 @@ void ProcessBinding(MouseContextType context, ClientNode *np,
       if(np) {
          if(np->state.maxFlags) {
             MaximizeClient(np, MAX_NONE);
-         } else {
+         } else if(np->state.border & BORDER_MIN) {
             MinimizeClient(np, 1);
          }
       }

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -379,7 +379,7 @@ void MinimizeGroup(const TaskEntry *tp)
 {
    ClientEntry *cp;
    for(cp = tp->clients; cp; cp = cp->next) {
-      if(ShouldFocus(cp->client, 1)) {
+      if(ShouldFocus(cp->client, 1) && (cp->client->state.border & BORDER_MIN)) {
          MinimizeClient(cp->client, 0);
       }
    }


### PR DESCRIPTION
Fixes shortcuts, taskbar and show desktop button so that 'nomin' windows aren't minimized.

Closes #619