### PR TITLE
Clear 'ACTIVE' on minimized when changing desktop

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -176,6 +176,9 @@ void ChangeDesktop(unsigned int desktop)
          }
          if(np->state.desktop == currentDesktop) {
             HideClient(np);
+            if((np->state.status & STAT_MINIMIZED) && (np->state.status & STAT_ACTIVE)) {
+               np->state.status &= ~STAT_ACTIVE;
+            }
          }
       }
    }


### PR DESCRIPTION
Clears 'ACTIVE' stat on minimized active window when switching desktop to prevent incorrect use of Active style.

Closes #621