### PR TITLE
Prevent 'center' action bypassing screen bounds

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -713,6 +713,7 @@ void ProcessBinding(MouseContextType context, ClientNode *np,
 
          np->x = sp->x + (sp->width - np->width) / 2;
          np->y = sp->y + (sp->height - np->height) / 2;
+         ConstrainPosition(np);
          ResetBorder(np);
          SendConfigureEvent(np);
          RequirePagerUpdate();


### PR DESCRIPTION
Avoids 'center' obscuring the title bar of a window by constraining its position after moving the window.

Closes #627