### PR TITLE
allow any gettext version (current is 0.22)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -479,7 +479,7 @@ fi
 ############################################################################
 AM_ICONV
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.20])
+AM_GNU_GETTEXT_VERSION
 LDFLAGS="$LDFLAGS $LIBINTL $LIBICONV"
 
 ############################################################################


### PR DESCRIPTION
with current getting error:

```
gettext version 0.20 but the autoconf macros are from gettext version 0.22
```