### PR TITLE
Fix autogen.sh failing to find gettext

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-aclocal
+mkdir -p m4
+aclocal -I m4
 automake -ac
-autoreconf -fi
+autoreconf -fi -I m4
 touch config.rpath


### PR DESCRIPTION
...which was preventing proper ./configure generation and making build from git sources impossible. Now it should look for gettext inside of ./m4/* before trying to get it from system directories.

Running autogen.sh still produces some warnings about missing gettext variables and errors about missing 'Makefile.am' files but './configure && make' should succeed anyway without any issues.

This issue was mentioned in:
https://github.com/joewing/jwm/issues/659#issuecomment-3352986637 https://github.com/joewing/jwm/issues/658#issuecomment-3243723531

Tested on latest ArchLinux with:
gettext (GNU gettext-runtime) 0.26
automake (GNU automake) 1.18.1
autoconf (GNU Autoconf) 2.72

also tested on Ubuntu 25.04 with:
gettext (GNU gettext-runtime) 0.23.1
automake (GNU automake) 1.17
autoconf (GNU Autoconf) 2.72