### PR TITLE
Add filename and source line to warning about invalid key

### DIFF
--- a/src/binding.c
+++ b/src/binding.c
@@ -74,7 +74,7 @@ static KeyNode *bindings[MC_COUNT];
 unsigned lockMask;
 
 static unsigned int GetModifierMask(XModifierKeymap *modmap, KeySym key);
-static KeySym ParseKeyString(const char *str);
+static KeySym ParseKeyString(const char *str, const char* fileName, int line);
 static char ShouldGrab(ActionType key);
 static void GrabKey(KeyNode *np, Window win);
 
@@ -371,12 +371,12 @@ unsigned int ParseModifierString(const char *str)
 }
 
 /** Parse a key string. */
-KeySym ParseKeyString(const char *str)
+KeySym ParseKeyString(const char *str, const char* fileName, int line)
 {
    KeySym symbol;
    symbol = JXStringToKeysym(str);
    if(JUNLIKELY(symbol == NoSymbol)) {
-      Warning(_("invalid key symbol: \"%s\""), str);
+      Warning(_("%s[%u]: invalid key symbol: \"%s\""), fileName, line, str);
    }
    return symbol;
 }
@@ -405,7 +405,7 @@ void RemoveDuplicates(KeyNode *bp)
 /** Insert a key binding. */
 void InsertBinding(ActionType action, const char *modifiers,
                    const char *stroke, const char *code,
-                   const char *command)
+                   const char *command, const char *fileName, int line)
 {
 
    KeyNode *np;
@@ -425,7 +425,7 @@ void InsertBinding(ActionType action, const char *modifiers,
 
             for(temp[offset] = '1'; temp[offset] <= '9'; temp[offset]++) {
 
-               sym = ParseKeyString(temp);
+               sym = ParseKeyString(temp, fileName, line);
                if(sym == NoSymbol) {
                   Release(temp);
                   return;
@@ -452,7 +452,7 @@ void InsertBinding(ActionType action, const char *modifiers,
          }
       }
 
-      sym = ParseKeyString(stroke);
+      sym = ParseKeyString(stroke, fileName, line);
       if(sym == NoSymbol) {
          return;
       }

--- a/src/binding.h
+++ b/src/binding.h
@@ -38,7 +38,8 @@ unsigned int ParseModifierString(const char *str);
  * @param command Extra parameter needed for some key binding types.
  */
 void InsertBinding(ActionType action, const char *modifiers,
-                   const char *stroke, const char *code, const char *command);
+                   const char *stroke, const char *code, const char *command,
+                   const char *fileName, int line);
 
 /** Insert a mouse binding.
  * A mouse binding maps a mouse click in a certain context to an action.

--- a/src/parse.c
+++ b/src/parse.c
@@ -957,7 +957,7 @@ void ParseKey(const TokenNode *tp)
    if(JUNLIKELY(k.action == ACTION_INVALID)) {
       ParseError(tp, _("invalid Key action: \"%s\""), action);
    } else {
-      InsertBinding(k, mask, key, code, command);
+      InsertBinding(k, mask, key, code, command, tp->fileName, tp->line);
    }
 }
 


### PR DESCRIPTION
Before this commit in case of error "invalid key" there was no information about location of error inside configuration file. This commit simplifies way to find error location by adding line numbers inside warning message.

Before:

JWM: warning: invalid key symbol: "`"

After:

JWM: warning: $HOME/.jwmrc[274]: invalid key symbol: "`"

May be there are more messages to be improved, I don't know.