### PR TITLE
avoid continuous growth of memory usage in case of scaled xrender images

### DIFF
--- a/src/icon.c
+++ b/src/icon.c
@@ -598,6 +598,10 @@ ScaledIconNode *GetScaledIcon(IconNode *icon, long fg,
          if(icon->render) {
             if(icon->images == NULL || icon->images->next == NULL) {
                return np;
+            } else {
+               if(np->renderWidth == nwidth && np->renderHeight == nheight) {
+                  return np;
+               }
             }
          }
 #endif
@@ -617,6 +621,8 @@ ScaledIconNode *GetScaledIcon(IconNode *icon, long fg,
 #ifdef USE_XRENDER
    if(icon->render) {
       np = CreateScaledRenderIcon(imageNode, fg);
+      np->renderWidth = nwidth;
+      np->renderHeight = nheight;
       np->next = icon->nodes;
       icon->nodes = np;
 

--- a/src/icon.h
+++ b/src/icon.h
@@ -15,8 +15,12 @@ struct ClientNode;
 /** Structure to hold a scaled icon. */
 typedef struct ScaledIconNode {
 
-   int width;   /**< The scaled width of the icon. */
-   int height;  /**< The scaled height of the icon. */
+   int width;           /**< The scaled width of the icon. */
+   int height;          /**< The scaled height of the icon. */
+#ifdef USE_XRENDER
+   int renderWidth;     /**< The width of the icon for xrender */
+   int renderHeight;    /**< The height of the icon for xrender */
+#endif
    long fg;     /**< Foreground color for bitmaps. */
 
    XID image;


### PR DESCRIPTION
In case of xrender and usage of scaled images JWM had growing memory consumption due to allocation of new ScaledIconNode if icon is requested. For instance, on each focus change the icon is requested and new ScaledIconNode had been allocated. xrestop shows it as well as increasing pixmap bytes and amount of pictures.

The reason is that CreateScaledRenderIcon returns unscaled icon and PutScaledRenderIcon makes actual scaling. The lookup in list of scaled icons assumed that all icons are already scaled and found nothing, then created new one, put it into list and so on.

This commit corrects lookup of ScaledIconNode by adding additional fields to handle post-scaling by xrender.