### PR TITLE
[cosmetic] remove fribidi bits from jwm.h

### DIFF
--- a/src/jwm.h
+++ b/src/jwm.h
@@ -100,9 +100,6 @@
 #  ifdef USE_XRENDER
 #     include <X11/extensions/Xrender.h>
 #  endif
-#  ifdef USE_FRIBIDI
-#     include <fribidi/fribidi.h>
-#  endif
 
 #endif /* MAKE_DEPEND */
 


### PR DESCRIPTION
Since 2.4.0 the library fribidi has been not used, so it may be worth to remove usage of header file from jwm.h