### PR TITLE
Per-monitor task lists, multi-row task buttons, task button drag reordering

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,6 +475,24 @@ if test "$enable_xinerama" != "no"; then
 fi
 
 ############################################################################
+# Check if support for XRandR was requested and available.
+# Used only to name Xinerama screens after RandR outputs (and find the
+# primary output); requires Xinerama.
+############################################################################
+AC_ARG_ENABLE(xrandr,
+   AS_HELP_STRING([--disable-xrandr],[disable XRandR support]) )
+if test "$enable_xrandr" != "no" -a "$enable_xinerama" = "yes"; then
+   AC_CHECK_LIB(Xrandr, XRRGetScreenResourcesCurrent,
+      [ LDFLAGS="$LDFLAGS -lXrandr"
+        enable_xrandr="yes"
+        AC_DEFINE(USE_XRANDR, 1, [Define to enable XRandR]) ],
+      [ enable_xrandr="no"
+        AC_MSG_WARN([unable to use XRandR]) ])
+else
+   enable_xrandr="no"
+fi
+
+############################################################################
 # Check if support for gettext was requested and available.
 ############################################################################
 AM_ICONV
@@ -580,6 +598,7 @@ echo "    Pango:    $enable_pango"
 echo "    Shape:    $enable_shape"
 echo "    Xmu:      $enable_xmu"
 echo "    Xinerama: $enable_xinerama"
+echo "    XRandR:   $enable_xrandr"
 echo "    Debug:    $enable_debug"
 echo
 

--- a/jwm.1.in
+++ b/jwm.1.in
@@ -511,10 +511,13 @@ optimal height depending on what it contains and the layout. A negative
 value subtracts from the screen height. 0 is the default.
 .RE
 .P
-\fBscreen\fP \fIint\fP
+\fBscreen\fP \fIstring\fP
 .RS
-The index of the screen on which to start the tray.
-0 is the default (the primary screen).
+The screen on which to place the tray: a Xinerama screen index
+(0 is the default), or, when JWM is compiled with XRandR support,
+a RandR output name (for example "DP-2") or the string "primary"
+for the primary output. An unknown name falls back to screen 0
+with a warning.
 .RE
 .P
 \fBlayer\fP { \fBbelow\fP | \fBnormal\fP | \fBabove\fP }

--- a/jwm.1.in
+++ b/jwm.1.in
@@ -676,6 +676,8 @@ the default.
 .B TaskList
 .RS
 Add a task list to the tray.
+Task buttons can be reordered by dragging them with the left mouse
+button; a click without dragging activates or minimizes the task.
 This tag supports the following attributes:
 .P
 \fBheight\fP \fIint\fP

--- a/jwm.1.in
+++ b/jwm.1.in
@@ -700,6 +700,24 @@ or "bottom" is chosen, an alternate method for resizing the task list will be us
 The maximum width of an item in the task list. 0 indicates no maximum.
 The default is 0.
 .RE
+.P
+\fBrows\fP \fIint\fP
+.RS
+The number of button rows for a horizontal task list (1 to 8).
+With more than one row, buttons are placed row-major and the item
+height is the tray height divided by the number of rows.
+The default is 1.
+.RE
+.P
+\fBscreen\fP \fIstring\fP
+.RS
+Limit the task list to clients on a Xinerama screen: "all" shows
+clients from every screen, "local" shows only clients whose dominant
+screen is the screen of the tray containing this task list, and a
+number selects an explicit screen index. A client belongs to the
+screen containing the largest part of its window.
+The default is "all".
+.RE
 .RE
 .P
 .B TrayButton

--- a/src/client.c
+++ b/src/client.c
@@ -148,6 +148,8 @@ ClientNode *AddClientWindow(Window w, char alreadyMapped, char notOwner)
    np->y = attr.y;
    np->width = attr.width;
    np->height = attr.height;
+   np->screenIndex = GetDominantScreen(np->x, np->y,
+                                       np->width, np->height)->index;
    np->cmap = attr.colormap;
    np->state.status = STAT_NONE;
    np->state.maxFlags = MAX_NONE;
@@ -1409,8 +1411,18 @@ void SendConfigureEvent(ClientNode *np)
 
    XConfigureEvent event;
    const ScreenType *sp;
+   int screenIndex;
 
    Assert(np);
+
+   /* Update the cached dominant screen; refresh screen-bound
+    * taskbars when the client moves to another screen. */
+   screenIndex = GetDominantScreen(np->x, np->y,
+                                   np->width, np->height)->index;
+   if(screenIndex != np->screenIndex) {
+      np->screenIndex = screenIndex;
+      RequireTaskUpdate();
+   }
 
    memset(&event, 0, sizeof(event));
    event.display = display;

--- a/src/client.c
+++ b/src/client.c
@@ -1421,6 +1421,7 @@ void SendConfigureEvent(ClientNode *np)
                                    np->width, np->height)->index;
    if(screenIndex != np->screenIndex) {
       np->screenIndex = screenIndex;
+      MoveClientToTaskBarEnd(np);
       RequireTaskUpdate();
    }
 

--- a/src/client.h
+++ b/src/client.h
@@ -128,6 +128,7 @@ typedef struct ClientNode {
    int oldy;                  /**< The old y coordinate (for maximize). */
    int oldWidth;              /**< The old width (for maximize). */
    int oldHeight;             /**< The old height (for maximize). */
+   int screenIndex;           /**< Cached dominant screen index. */
 
    long sizeFlags;            /**< Size flags from XGetWMNormalHints. */
    int baseWidth;             /**< Base width for resizing. */

--- a/src/event.c
+++ b/src/event.c
@@ -307,13 +307,15 @@ void ProcessEvent(XEvent *event)
    }
 }
 
-/** Discard button events for the specified windows. */
+/** Discard button events for the specified windows.
+ * Note that only presses are discarded: a queued release may pair
+ * with the press being processed (fast click) and components with
+ * a release handler depend on receiving it. */
 void DiscardButtonEvents()
 {
    XEvent event;
    JXSync(display, False);
-   while(JXCheckMaskEvent(display, ButtonPressMask | ButtonReleaseMask,
-			  &event)) {
+   while(JXCheckMaskEvent(display, ButtonPressMask, &event)) {
       UpdateTime(&event);
    }
 }

--- a/src/jwm.h
+++ b/src/jwm.h
@@ -91,6 +91,9 @@
 #  ifdef USE_XINERAMA
 #     include <X11/extensions/Xinerama.h>
 #  endif
+#  ifdef USE_XRANDR
+#     include <X11/extensions/Xrandr.h>
+#  endif
 #  ifdef USE_XFT
 #     ifdef HAVE_FT2BUILD_H
 #        include <ft2build.h>

--- a/src/parse.c
+++ b/src/parse.c
@@ -1514,6 +1514,11 @@ void ParseTaskList(const TokenNode *tp, TrayType *tray)
       SetTaskBarScreenFilter(cp, temp);
    }
 
+   temp = FindAttribute(tp->attributes, "rows");
+   if(temp) {
+      SetTaskBarRows(cp, temp);
+   }
+
 }
 
 /** Parse the tray button style. */

--- a/src/parse.c
+++ b/src/parse.c
@@ -1509,6 +1509,11 @@ void ParseTaskList(const TokenNode *tp, TrayType *tray)
       SetTaskBarLabelPosition(cp, temp);
    }
 
+   temp = FindAttribute(tp->attributes, "screen");
+   if(temp) {
+      SetTaskBarScreenFilter(cp, temp);
+   }
+
 }
 
 /** Parse the tray button style. */

--- a/src/screen.c
+++ b/src/screen.c
@@ -20,6 +20,57 @@
 static ScreenType *screens = NULL;
 static int screenCount;
 
+#ifdef USE_XRANDR
+/** Name screens after the RandR outputs driving them.
+ * Each active CRTC rectangle is matched to the Xinerama screen with
+ * the same geometry (modern servers synthesize Xinerama data from the
+ * CRTC configuration, so an exact match is expected). */
+static void NameScreens(void)
+{
+   XRRScreenResources *res;
+   RROutput primary;
+   int eventBase, errorBase;
+   int i, x;
+
+   if(!XRRQueryExtension(display, &eventBase, &errorBase)) {
+      return;
+   }
+   res = XRRGetScreenResourcesCurrent(display, rootWindow);
+   if(!res) {
+      return;
+   }
+   primary = XRRGetOutputPrimary(display, rootWindow);
+   for(i = 0; i < res->noutput; i++) {
+      XRROutputInfo *output;
+      output = XRRGetOutputInfo(display, res, res->outputs[i]);
+      if(!output) {
+         continue;
+      }
+      if(output->connection == RR_Connected && output->crtc != None) {
+         XRRCrtcInfo *crtc = XRRGetCrtcInfo(display, res, output->crtc);
+         if(crtc) {
+            for(x = 0; x < screenCount; x++) {
+               if(screens[x].name == NULL
+                  && screens[x].x == crtc->x
+                  && screens[x].y == crtc->y
+                  && screens[x].width == (int)crtc->width
+                  && screens[x].height == (int)crtc->height) {
+                  screens[x].name = CopyString(output->name);
+                  screens[x].primary = res->outputs[i] == primary;
+                  Debug("screen %d: %s%s", x, output->name,
+                        screens[x].primary ? " (primary)" : "");
+                  break;
+               }
+            }
+            XRRFreeCrtcInfo(crtc);
+         }
+      }
+      XRRFreeOutputInfo(output);
+   }
+   XRRFreeScreenResources(res);
+}
+#endif /* USE_XRANDR */
+
 /** Startup screens. */
 void StartupScreens(void)
 {
@@ -39,9 +90,15 @@ void StartupScreens(void)
          screens[x].y = info[x].y_org;
          screens[x].width = info[x].width;
          screens[x].height = info[x].height;
+         screens[x].name = NULL;
+         screens[x].primary = 0;
       }
 
       JXFree(info);
+
+#ifdef USE_XRANDR
+      NameScreens();
+#endif
 
    } else {
 
@@ -52,6 +109,8 @@ void StartupScreens(void)
       screens->y = 0;
       screens->width = rootWidth;
       screens->height = rootHeight;
+      screens->name = NULL;
+      screens->primary = 1;
 
    }
 
@@ -64,6 +123,8 @@ void StartupScreens(void)
    screens->y = 0;
    screens->width = rootWidth;
    screens->height = rootHeight;
+   screens->name = NULL;
+   screens->primary = 1;
 
 #endif /* USE_XINERAMA */
 }
@@ -72,9 +133,35 @@ void StartupScreens(void)
 void ShutdownScreens(void)
 {
    if(screens) {
+      int x;
+      for(x = 0; x < screenCount; x++) {
+         if(screens[x].name) {
+            Release(screens[x].name);
+         }
+      }
       Release(screens);
       screens = NULL;
    }
+}
+
+/** Find a screen by RandR output name. */
+int FindScreenByName(const char *name)
+{
+   int x;
+   Assert(name);
+   for(x = 0; x < screenCount; x++) {
+      if(screens[x].name && !strcmp(screens[x].name, name)) {
+         return x;
+      }
+   }
+   if(!strcmp(name, "primary")) {
+      for(x = 0; x < screenCount; x++) {
+         if(screens[x].primary) {
+            return x;
+         }
+      }
+   }
+   return -1;
 }
 
 /** Get the screen given global screen coordinates. */

--- a/src/screen.c
+++ b/src/screen.c
@@ -101,6 +101,39 @@ const ScreenType *GetCurrentScreen(int x, int y)
 
 }
 
+/** Get the screen with the largest overlap with a rectangle. */
+const ScreenType *GetDominantScreen(int x, int y, int width, int height)
+{
+
+   const ScreenType *best;
+   int bestArea;
+   int index;
+
+   best = NULL;
+   bestArea = 0;
+   for(index = 0; index < screenCount; index++) {
+      const ScreenType *sp = &screens[index];
+      const int ix = Max(x, sp->x);
+      const int iy = Max(y, sp->y);
+      const int iw = Min(x + width, sp->x + sp->width) - ix;
+      const int ih = Min(y + height, sp->y + sp->height) - iy;
+      if(iw > 0 && ih > 0) {
+         const int area = iw * ih;
+         if(area > bestArea) {
+            bestArea = area;
+            best = sp;
+         }
+      }
+   }
+   if(best) {
+      return best;
+   }
+
+   /* No overlap with any screen; fall back to the midpoint. */
+   return GetCurrentScreen(x + width / 2, y + height / 2);
+
+}
+
 /** Get the screen the mouse is currently on. */
 const ScreenType *GetMouseScreen(void)
 {

--- a/src/screen.h
+++ b/src/screen.h
@@ -35,6 +35,17 @@ void ShutdownScreens(void);
  */
 const ScreenType *GetCurrentScreen(int x, int y);
 
+/** Get the screen with the largest overlap with a rectangle.
+ * Falls back to the screen containing the rectangle midpoint when
+ * there is no overlap with any screen.
+ * @param x The x-coordinate of the rectangle.
+ * @param y The y-coordinate of the rectangle.
+ * @param width The width of the rectangle.
+ * @param height The height of the rectangle.
+ * @return The screen (never NULL).
+ */
+const ScreenType *GetDominantScreen(int x, int y, int width, int height);
+
 /** Get the screen containing the mouse.
  * @return The screen containing the mouse.
  */

--- a/src/screen.h
+++ b/src/screen.h
@@ -19,6 +19,8 @@ typedef struct ScreenType {
    int index;           /**< The index of this screen. */
    int x, y;            /**< The location of this screen. */
    int width, height;   /**< The size of this screen. */
+   char *name;          /**< RandR output name (NULL if unknown). */
+   char primary;        /**< 1 if this is the primary output. */
 } ScreenType;
 
 /*@{*/
@@ -61,6 +63,13 @@ const ScreenType *GetScreen(int index);
  * @return The number of screens.
  */
 int GetScreenCount(void);
+
+/** Find a screen by RandR output name.
+ * The name "primary" matches the primary output.
+ * @param name The output name (e.g. "DP-2").
+ * @return The screen index or -1 if not found (or names unknown).
+ */
+int FindScreenByName(const char *name);
 
 #endif /* SCREEN_H */
 

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -39,6 +39,8 @@ typedef struct TaskBarType {
    int maxItemWidth;
    int userHeight;
    int screenFilter;
+   unsigned rows;       /**< Requested button rows (horizontal only). */
+   unsigned columns;    /**< Computed button columns. */
    int itemHeight;
    int itemWidth;
    LayoutType layout;
@@ -136,6 +138,8 @@ TrayComponentType *CreateTaskBar()
    tp->userHeight = 0;
    tp->maxItemWidth = 0;
    tp->screenFilter = SCREEN_FILTER_ALL;
+   tp->rows = 1;
+   tp->columns = 1;
    tp->layout = LAYOUT_HORIZONTAL;
    tp->labeled = 1;
    tp->labelPos = LABEL_POSITION_RIGHT;
@@ -217,6 +221,7 @@ void ComputeItemSize(TaskBarType *tp)
    TrayComponentType *cp = tp->cp;
 
    if(tp->layout == LAYOUT_VERTICAL) {
+      tp->columns = 1;
       if(tp->labelPos > LABEL_POSITION_RIGHT) {
          unsigned itemCount = TallyVisibleItems(tp);
          if(itemCount == 0) {
@@ -241,12 +246,15 @@ void ComputeItemSize(TaskBarType *tp)
       }
    } else {
       unsigned itemCount = TallyVisibleItems(tp);
+      unsigned rows;
       if(itemCount == 0) {
          return;
       }
 
-      tp->itemHeight = cp->height;
-      tp->itemWidth = Max(1, cp->width / itemCount);
+      rows = Max(1, tp->rows);
+      tp->columns = Max(1, (itemCount + rows - 1) / rows);
+      tp->itemHeight = Max(1, cp->height / (int)rows);
+      tp->itemWidth = Max(1, cp->width / (int)tp->columns);
 
       if(!tp->labeled) {
          tp->itemWidth = Min(tp->itemHeight, tp->itemWidth);
@@ -807,6 +815,7 @@ void Render(const TaskBarType *bp)
    char *displayName;
    ButtonNode button;
    int x, y;
+   unsigned visible;
 
    if(JUNLIKELY(shouldExit)) {
       return;
@@ -828,10 +837,21 @@ void Render(const TaskBarType *bp)
 
    x = 0;
    y = 0;
+   visible = 0;
    for(tp = taskEntries; tp; tp = tp->next) {
 
       if(!ShouldShowEntry(bp, tp)) {
          continue;
+      }
+
+      /* Row-major placement; a single row reduces to the classic
+       * layout since columns then equals the visible item count. */
+      if(bp->layout == LAYOUT_HORIZONTAL) {
+         x = (visible % bp->columns) * bp->itemWidth;
+         y = (visible / bp->columns) * bp->itemHeight;
+      } else {
+         x = 0;
+         y = visible * bp->itemHeight;
       }
 
       /* Check for an active or urgent window and count clients. */
@@ -887,11 +907,7 @@ void Render(const TaskBarType *bp)
          Release(displayName);
       }
 
-      if(bp->layout == LAYOUT_HORIZONTAL) {
-         x += bp->itemWidth;
-      } else {
-         y += bp->itemHeight;
-      }
+      visible += 1;
    }
 
    UpdateSpecificTray(bp->cp->tray, bp->cp);
@@ -1050,27 +1066,48 @@ char ShouldFocusEntry(const TaskEntry *tp)
 TaskEntry *GetEntry(TaskBarType *bar, int x, int y)
 {
    TaskEntry *tp;
-   int offset;
+   unsigned index, target;
 
-   offset = 0;
+   if(bar->layout == LAYOUT_HORIZONTAL) {
+      const unsigned col = x / Max(1, bar->itemWidth);
+      const unsigned row = y / Max(1, bar->itemHeight);
+      if(col >= bar->columns) {
+         return NULL;
+      }
+      target = row * bar->columns + col;
+   } else {
+      target = y / Max(1, bar->itemHeight);
+   }
+
+   index = 0;
    for(tp = taskEntries; tp; tp = tp->next) {
       if(!ShouldShowEntry(bar, tp)) {
          continue;
       }
-      if(bar->layout == LAYOUT_HORIZONTAL) {
-         offset += bar->itemWidth;
-         if(x < offset) {
-            return tp;
-         }
-      } else {
-         offset += bar->itemHeight;
-         if(y < offset) {
-            return tp;
-         }
+      if(index == target) {
+         return tp;
       }
+      index += 1;
    }
 
    return NULL;
+}
+
+/** Set the number of button rows for the specified task bar. */
+void SetTaskBarRows(TrayComponentType *cp, const char *value)
+{
+   TaskBarType *bp = (TaskBarType*)cp->object;
+   int temp;
+
+   Assert(cp);
+   Assert(value);
+
+   temp = atoi(value);
+   if(JUNLIKELY(temp < 1 || temp > 8)) {
+      Warning(_("invalid rows for TaskList: %s"), value);
+      return;
+   }
+   bp->rows = temp;
 }
 
 /** Set the screen filter for the specified task bar. */

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -27,6 +27,10 @@
 #include "misc.h"
 #include "desktop.h"
 
+/** Values for the TaskBarType screenFilter field. */
+#define SCREEN_FILTER_ALL     (-1)  /**< Show clients from all screens. */
+#define SCREEN_FILTER_LOCAL   (-2)  /**< Show the parent tray's screen. */
+
 typedef struct TaskBarType {
 
    TrayComponentType *cp;
@@ -34,6 +38,7 @@ typedef struct TaskBarType {
 
    int maxItemWidth;
    int userHeight;
+   int screenFilter;
    int itemHeight;
    int itemWidth;
    LayoutType layout;
@@ -63,9 +68,11 @@ static TaskBarType *bars;
 static TaskEntry *taskEntries;
 static TaskEntry *taskEntriesTail;
 
-static unsigned TallyVisibleItems(void);
+static unsigned TallyVisibleItems(const TaskBarType *bp);
 static void ComputeItemSize(TaskBarType *tp);
-static char ShouldShowEntry(const TaskEntry *tp);
+static int GetBarScreen(const TaskBarType *bp);
+static char ShouldShowClient(const TaskBarType *bp, const ClientNode *np);
+static char ShouldShowEntry(const TaskBarType *bp, const TaskEntry *tp);
 static char ShouldFocusEntry(const TaskEntry *tp);
 static TaskEntry *GetEntry(TaskBarType *bar, int x, int y);
 static void Render(const TaskBarType *bp);
@@ -128,6 +135,7 @@ TrayComponentType *CreateTaskBar()
    tp->itemWidth = 0;
    tp->userHeight = 0;
    tp->maxItemWidth = 0;
+   tp->screenFilter = SCREEN_FILTER_ALL;
    tp->layout = LAYOUT_HORIZONTAL;
    tp->labeled = 1;
    tp->labelPos = LABEL_POSITION_RIGHT;
@@ -191,12 +199,12 @@ void Resize(TrayComponentType *cp)
 }
 
 /** Count the number of items that should be shown in the task bar. */
-unsigned TallyVisibleItems(void)
+unsigned TallyVisibleItems(const TaskBarType *bp)
 {
    TaskEntry *ep;
    unsigned count = 0;
    for(ep = taskEntries; ep; ep = ep->next) {
-      if(ShouldShowEntry(ep)) {
+      if(ShouldShowEntry(bp, ep)) {
          count += 1;
       }
    }
@@ -210,7 +218,7 @@ void ComputeItemSize(TaskBarType *tp)
 
    if(tp->layout == LAYOUT_VERTICAL) {
       if(tp->labelPos > LABEL_POSITION_RIGHT) {
-         unsigned itemCount = TallyVisibleItems();
+         unsigned itemCount = TallyVisibleItems(tp);
          if(itemCount == 0) {
             return;
          }
@@ -232,7 +240,7 @@ void ComputeItemSize(TaskBarType *tp)
          tp->itemWidth = cp->width;
       }
    } else {
-      unsigned itemCount = TallyVisibleItems();
+      unsigned itemCount = TallyVisibleItems(tp);
       if(itemCount == 0) {
          return;
       }
@@ -752,7 +760,7 @@ void UpdateTaskBar(void)
          }
          bp->cp->requestedHeight = 0;
          for(tp = taskEntries; tp; tp = tp->next) {
-            if(ShouldShowEntry(tp)) {
+            if(ShouldShowEntry(bp, tp)) {
                bp->cp->requestedHeight += bp->itemHeight;
             }
          }
@@ -822,7 +830,7 @@ void Render(const TaskBarType *bp)
    y = 0;
    for(tp = taskEntries; tp; tp = tp->next) {
 
-      if(!ShouldShowEntry(tp)) {
+      if(!ShouldShowEntry(bp, tp)) {
          continue;
       }
 
@@ -831,7 +839,7 @@ void Render(const TaskBarType *bp)
       unsigned clientCount = 0;
       button.type = BUTTON_TASK;
       for(cp = tp->clients; cp; cp = cp->next) {
-         if(ShouldFocus(cp->client, 0)) {
+         if(ShouldShowClient(bp, cp->client)) {
             const char flash = (cp->client->state.status & STAT_FLASH) != 0;
             const char active = (cp->client->state.status & STAT_ACTIVE)
                && IsClientOnCurrentDesktop(cp->client);
@@ -990,12 +998,34 @@ void FocusAt(char n)
    }
 }
 
+/** Get the screen index a task bar is filtered to. */
+int GetBarScreen(const TaskBarType *bp)
+{
+   if(bp->screenFilter == SCREEN_FILTER_LOCAL) {
+      return bp->cp->tray->screen;
+   }
+   return bp->screenFilter;
+}
+
+/** Determine if a client should be shown on the specified task bar. */
+char ShouldShowClient(const TaskBarType *bp, const ClientNode *np)
+{
+   if(!ShouldFocus(np, 0)) {
+      return 0;
+   }
+   if(bp->screenFilter != SCREEN_FILTER_ALL
+      && np->screenIndex != GetBarScreen(bp)) {
+      return 0;
+   }
+   return 1;
+}
+
 /** Determine if there is anything to show for the specified entry. */
-char ShouldShowEntry(const TaskEntry *tp)
+char ShouldShowEntry(const TaskBarType *bp, const TaskEntry *tp)
 {
    const ClientEntry *cp;
    for(cp = tp->clients; cp; cp = cp->next) {
-      if(ShouldFocus(cp->client, 0)) {
+      if(ShouldShowClient(bp, cp->client)) {
          return 1;
       }
    }
@@ -1024,7 +1054,7 @@ TaskEntry *GetEntry(TaskBarType *bar, int x, int y)
 
    offset = 0;
    for(tp = taskEntries; tp; tp = tp->next) {
-      if(!ShouldShowEntry(tp)) {
+      if(!ShouldShowEntry(bar, tp)) {
          continue;
       }
       if(bar->layout == LAYOUT_HORIZONTAL) {
@@ -1041,6 +1071,25 @@ TaskEntry *GetEntry(TaskBarType *bar, int x, int y)
    }
 
    return NULL;
+}
+
+/** Set the screen filter for the specified task bar. */
+void SetTaskBarScreenFilter(TrayComponentType *cp, const char *value)
+{
+   TaskBarType *bp = (TaskBarType*)cp->object;
+
+   Assert(cp);
+   Assert(value);
+
+   if(!strcmp(value, "local")) {
+      bp->screenFilter = SCREEN_FILTER_LOCAL;
+   } else if(!strcmp(value, "all")) {
+      bp->screenFilter = SCREEN_FILTER_ALL;
+   } else if(value[0] >= '0' && value[0] <= '9') {
+      bp->screenFilter = atoi(value);
+   } else {
+      Warning(_("invalid screen for TaskList: %s"), value);
+   }
 }
 
 /** Set the maximum width of an item in the task bar. */

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -52,6 +52,10 @@ typedef struct TaskBarType {
    TimeType mouseTime;
    int mousex, mousey;
 
+   struct TaskEntry *dragEntry;  /**< Pressed entry (drag candidate). */
+   int dragx, dragy;             /**< Position of the button press. */
+   char dragging;                /**< 1 once a drag is in progress. */
+
 } TaskBarType;
 
 typedef struct ClientEntry {
@@ -86,6 +90,10 @@ static void Create(TrayComponentType *cp);
 static void Resize(TrayComponentType *cp);
 static void ProcessTaskButtonEvent(TrayComponentType *cp,
                                    int x, int y, int mask);
+static void ProcessTaskButtonRelease(TrayComponentType *cp,
+                                     int x, int y, int mask);
+static void HandleTaskClick(TaskEntry *entry);
+static void MoveTaskEntry(TaskEntry *entry, TaskEntry *target);
 static void MinimizeGroup(const TaskEntry *tp);
 static void FocusGroup(const TaskEntry *tp);
 static char IsGroupOnTop(const TaskEntry *entry);
@@ -147,6 +155,10 @@ TrayComponentType *CreateTaskBar()
    tp->mousey = -settings.doubleClickDelta;
    tp->mouseTime.seconds = 0;
    tp->mouseTime.ms = 0;
+   tp->dragEntry = NULL;
+   tp->dragx = 0;
+   tp->dragy = 0;
+   tp->dragging = 0;
 
    cp = CreateTrayComponent();
    cp->object = tp;
@@ -156,6 +168,7 @@ TrayComponentType *CreateTaskBar()
    cp->Create = Create;
    cp->Resize = Resize;
    cp->ProcessButtonPress = ProcessTaskButtonEvent;
+   cp->ProcessButtonRelease = ProcessTaskButtonRelease;
    cp->ProcessMotionEvent = ProcessTaskMotionEvent;
 
    RegisterCallback(settings.popupDelay / 2, SignalTaskbar, tp);
@@ -303,100 +316,23 @@ void ProcessTaskButtonEvent(TrayComponentType *cp, int x, int y, int mask)
    TaskEntry *entry = GetEntry(bar, x, y);
 
    if(entry) {
-      ClientEntry *cp;
-      ClientNode *focused = NULL;
-      char hasActive = 0;
-      char allTop;
+      ClientEntry *cp2;
 
       switch(mask) {
-      case Button1:  /* Raise or minimize items in this group. */
-
-         allTop = IsGroupOnTop(entry);
-         if(allTop) {
-            for(cp = entry->clients; cp; cp = cp->next) {
-               int layer;
-               if(cp->client->state.status & STAT_MINIMIZED) {
-                  continue;
-               } else if(!ShouldFocus(cp->client, 0)) {
-                  continue;
-               }
-               for(layer = LAST_LAYER; layer >= FIRST_LAYER; layer--) {
-                  ClientNode *np;
-                  for(np = nodes[layer]; np; np = np->next) {
-                     if(np->state.status & STAT_MINIMIZED) {
-                        continue;
-                     } else if(!ShouldFocus(np, 0)) {
-                        continue;
-                     }
-                     if(np == cp->client) {
-                        const char isActive = (np->state.status & STAT_ACTIVE)
-                                            && IsClientOnCurrentDesktop(np);
-                        if(isActive) {
-                           focused = np;
-                        }
-                        if(!(cp->client->state.status
-                              & (STAT_CANFOCUS | STAT_TAKEFOCUS))
-                           || isActive) {
-                           hasActive = 1;
-                        }
-                     }
-                     if(hasActive) {
-                        goto FoundActiveAndTop;
-                     }
-                  }
-               }
-            }
+      case Button1:
+         /* Arm a possible drag; the click action runs on release
+          * if no drag took place. */
+         if(GrabMouse(cp->tray->window)) {
+            cp->grabbed = 1;
          }
-FoundActiveAndTop:
-         if(hasActive && allTop) {
-            /* The client is already active.
-             * Here we switch desktops if the client is on another
-             * desktop too. Otherwise we minimize the client.
-             */
-            ClientNode *nextClient = NULL;
-            int i;
-
-            /* Try to find a client on a different desktop. */
-            for(i = 0; i < settings.desktopCount - 1; i++) {
-               const int target = (currentDesktop + i + 1)
-                                % settings.desktopCount;
-               for(cp = entry->clients; cp; cp = cp->next) {
-                  ClientNode *np = cp->client;
-                  if(!ShouldFocus(np, 0)) {
-                     continue;
-                  } else if(np->state.status & STAT_STICKY) {
-                     continue;
-                  } else if(np->state.desktop == target) {
-                     if(!nextClient || np->state.status & STAT_ACTIVE) {
-                        nextClient = np;
-                     }
-                  }
-               }
-               if(nextClient) {
-                  break;
-               }
-            }
-            /* Focus the next client or minimize the current group. */
-            if(nextClient) {
-               ChangeDesktop(nextClient->state.desktop);
-               RestoreClient(nextClient, 1);
-            } else {
-               MinimizeGroup(entry);
-            }
-         } else {
-            /* The group was not currently on top, raise the group. */
-            FocusGroup(entry);
-            if(focused) {
-               /* If the group already contained the active client,
-                * ensure that the same client remains active.
-                */
-               FocusClient(focused);
-            }
-         }
+         bar->dragEntry = entry;
+         bar->dragx = x;
+         bar->dragy = y;
+         bar->dragging = 0;
          break;
       case Button2:
-         for(cp = entry->clients; cp; cp = cp->next) {
-      	    DeleteClient(cp->client);
+         for(cp2 = entry->clients; cp2; cp2 = cp2->next) {
+      	    DeleteClient(cp2->client);
          }
          break;
       case Button3:
@@ -410,6 +346,115 @@ FoundActiveAndTop:
          break;
       default:
          break;
+      }
+   }
+
+}
+
+/** Handle a button release on the task bar. */
+void ProcessTaskButtonRelease(TrayComponentType *cp, int x, int y, int mask)
+{
+   TaskBarType *bar = (TaskBarType*)cp->object;
+   if(mask == Button1) {
+      if(bar->dragEntry && !bar->dragging) {
+         if(GetEntry(bar, x, y) == bar->dragEntry) {
+            HandleTaskClick(bar->dragEntry);
+         }
+      }
+      bar->dragEntry = NULL;
+      bar->dragging = 0;
+   }
+}
+
+/** Handle a (non-drag) left click on a task entry:
+ * raise or minimize the items in the group. */
+void HandleTaskClick(TaskEntry *entry)
+{
+   ClientEntry *cp;
+   ClientNode *focused = NULL;
+   char hasActive = 0;
+   char allTop;
+
+   allTop = IsGroupOnTop(entry);
+   if(allTop) {
+      for(cp = entry->clients; cp; cp = cp->next) {
+         int layer;
+         if(cp->client->state.status & STAT_MINIMIZED) {
+            continue;
+         } else if(!ShouldFocus(cp->client, 0)) {
+            continue;
+         }
+         for(layer = LAST_LAYER; layer >= FIRST_LAYER; layer--) {
+            ClientNode *np;
+            for(np = nodes[layer]; np; np = np->next) {
+               if(np->state.status & STAT_MINIMIZED) {
+                  continue;
+               } else if(!ShouldFocus(np, 0)) {
+                  continue;
+               }
+               if(np == cp->client) {
+                  const char isActive = (np->state.status & STAT_ACTIVE)
+                                      && IsClientOnCurrentDesktop(np);
+                  if(isActive) {
+                     focused = np;
+                  }
+                  if(!(cp->client->state.status
+                        & (STAT_CANFOCUS | STAT_TAKEFOCUS))
+                     || isActive) {
+                     hasActive = 1;
+                  }
+               }
+               if(hasActive) {
+                  goto FoundActiveAndTop;
+               }
+            }
+         }
+      }
+   }
+FoundActiveAndTop:
+   if(hasActive && allTop) {
+      /* The client is already active.
+       * Here we switch desktops if the client is on another
+       * desktop too. Otherwise we minimize the client.
+       */
+      ClientNode *nextClient = NULL;
+      int i;
+
+      /* Try to find a client on a different desktop. */
+      for(i = 0; i < settings.desktopCount - 1; i++) {
+         const int target = (currentDesktop + i + 1)
+                          % settings.desktopCount;
+         for(cp = entry->clients; cp; cp = cp->next) {
+            ClientNode *np = cp->client;
+            if(!ShouldFocus(np, 0)) {
+               continue;
+            } else if(np->state.status & STAT_STICKY) {
+               continue;
+            } else if(np->state.desktop == target) {
+               if(!nextClient || np->state.status & STAT_ACTIVE) {
+                  nextClient = np;
+               }
+            }
+         }
+         if(nextClient) {
+            break;
+         }
+      }
+      /* Focus the next client or minimize the current group. */
+      if(nextClient) {
+         ChangeDesktop(nextClient->state.desktop);
+         RestoreClient(nextClient, 1);
+      } else {
+         MinimizeGroup(entry);
+      }
+   } else {
+      /* The group was not currently on top, raise the group. */
+      FocusGroup(entry);
+      if(focused) {
+         /* If the group already contained the active client,
+          * ensure that the same client remains active.
+          */
+         FocusClient(focused);
       }
    }
 
@@ -512,6 +557,74 @@ void ProcessTaskMotionEvent(TrayComponentType *cp, int x, int y, int mask)
    bp->mousex = cp->screenx + x;
    bp->mousey = cp->screeny + y;
    GetCurrentTime(&bp->mouseTime);
+
+   /* Drag reordering of task buttons. */
+   if(bp->dragEntry && (mask & Button1Mask)) {
+      if(!bp->dragging) {
+         if(abs(x - bp->dragx) > (int)settings.doubleClickDelta
+            || abs(y - bp->dragy) > (int)settings.doubleClickDelta) {
+            bp->dragging = 1;
+         }
+      }
+      if(bp->dragging) {
+         TaskEntry *target = GetEntry(bp, x, y);
+         if(target && target != bp->dragEntry) {
+            MoveTaskEntry(bp->dragEntry, target);
+         }
+      }
+   }
+}
+
+/** Move a task entry to another entry's position (drag reorder). */
+void MoveTaskEntry(TaskEntry *entry, TaskEntry *target)
+{
+   TaskEntry *tp;
+   char isBefore;
+
+   /* Determine whether entry currently precedes target. */
+   isBefore = 0;
+   for(tp = entry->next; tp; tp = tp->next) {
+      if(tp == target) {
+         isBefore = 1;
+         break;
+      }
+   }
+
+   /* Unlink the entry. */
+   if(entry->prev) {
+      entry->prev->next = entry->next;
+   } else {
+      taskEntries = entry->next;
+   }
+   if(entry->next) {
+      entry->next->prev = entry->prev;
+   } else {
+      taskEntriesTail = entry->prev;
+   }
+
+   if(isBefore) {
+      /* Moving forward: insert after target. */
+      entry->prev = target;
+      entry->next = target->next;
+      if(target->next) {
+         target->next->prev = entry;
+      } else {
+         taskEntriesTail = entry;
+      }
+      target->next = entry;
+   } else {
+      /* Moving backward: insert before target. */
+      entry->next = target;
+      entry->prev = target->prev;
+      if(target->prev) {
+         target->prev->next = entry;
+      } else {
+         taskEntries = entry;
+      }
+      target->prev = entry;
+   }
+
+   RequireTaskUpdate();
 }
 
 /** Show the menu associated with a task list item. */
@@ -727,6 +840,14 @@ void RemoveClientFromTaskBar(ClientNode *np)
             }
             Release(cp);
             if(!tp->clients) {
+               TaskBarType *bp;
+               /* Forget any drag state referencing this entry. */
+               for(bp = bars; bp; bp = bp->next) {
+                  if(bp->dragEntry == tp) {
+                     bp->dragEntry = NULL;
+                     bp->dragging = 0;
+                  }
+               }
                if(tp->prev) {
                   tp->prev->next = tp->next;
                } else {

--- a/src/taskbar.c
+++ b/src/taskbar.c
@@ -1014,6 +1014,52 @@ void FocusAt(char n)
    }
 }
 
+/** Move a client's task entry to the end of the task list.
+ * Called when a client moves to another screen so that its button is
+ * appended after the existing buttons on the new screen's task bar.
+ * Only reorders when some task bar filters by screen; otherwise the
+ * global creation order is kept (the upstream behavior). */
+void MoveClientToTaskBarEnd(ClientNode *np)
+{
+   const TaskBarType *bp;
+   TaskEntry *tp;
+   char filtered;
+
+   filtered = 0;
+   for(bp = bars; bp; bp = bp->next) {
+      if(bp->screenFilter != SCREEN_FILTER_ALL) {
+         filtered = 1;
+         break;
+      }
+   }
+   if(!filtered) {
+      return;
+   }
+
+   for(tp = taskEntries; tp; tp = tp->next) {
+      const ClientEntry *cp;
+      for(cp = tp->clients; cp; cp = cp->next) {
+         if(cp->client == np) {
+            if(tp == taskEntriesTail) {
+               return;
+            }
+            if(tp->prev) {
+               tp->prev->next = tp->next;
+            } else {
+               taskEntries = tp->next;
+            }
+            tp->next->prev = tp->prev;
+            tp->prev = taskEntriesTail;
+            tp->next = NULL;
+            taskEntriesTail->next = tp;
+            taskEntriesTail = tp;
+            RequireTaskUpdate();
+            return;
+         }
+      }
+   }
+}
+
 /** Get the screen index a task bar is filtered to. */
 int GetBarScreen(const TaskBarType *bp)
 {

--- a/src/taskbar.h
+++ b/src/taskbar.h
@@ -47,6 +47,13 @@ void FocusNext(void);
 /** Focus the previous client in the task bar. */
 void FocusPrevious(void);
 
+/** Move a client's task entry to the end of the task list.
+ * Used when a client changes screens so its button is appended on the
+ * new screen's task bar. No-op unless some task bar filters by screen.
+ * @param np The client.
+ */
+void MoveClientToTaskBarEnd(struct ClientNode *np);
+
 /** Set the screen filter of a task bar.
  * @param cp The task bar component.
  * @param value "all" (default), "local" (the parent tray's screen),

--- a/src/taskbar.h
+++ b/src/taskbar.h
@@ -47,6 +47,13 @@ void FocusNext(void);
 /** Focus the previous client in the task bar. */
 void FocusPrevious(void);
 
+/** Set the screen filter of a task bar.
+ * @param cp The task bar component.
+ * @param value "all" (default), "local" (the parent tray's screen),
+ * or a screen index.
+ */
+void SetTaskBarScreenFilter(struct TrayComponentType *cp, const char *value);
+
 /** Set the maximum width of task bar items.
  * @param cp The task bar component.
  * @param value The maximum width.

--- a/src/taskbar.h
+++ b/src/taskbar.h
@@ -54,6 +54,12 @@ void FocusPrevious(void);
  */
 void SetTaskBarScreenFilter(struct TrayComponentType *cp, const char *value);
 
+/** Set the number of button rows of a horizontal task bar.
+ * @param cp The task bar component.
+ * @param value The number of rows (default 1).
+ */
+void SetTaskBarRows(struct TrayComponentType *cp, const char *value);
+
 /** Set the maximum width of task bar items.
  * @param cp The task bar component.
  * @param value The maximum width.

--- a/src/tray.c
+++ b/src/tray.c
@@ -74,6 +74,11 @@ void StartupTray(void)
 
    for(tp = trays; tp; tp = tp->next) {
 
+      if(tp->screen >= GetScreenCount()) {
+         Warning(_("tray screen index %d out of range"), tp->screen);
+         tp->screen = 0;
+      }
+
       LayoutTray(tp, &variableSize, &variableRemainder);
 
       /* Create the tray window. */

--- a/src/tray.c
+++ b/src/tray.c
@@ -74,6 +74,15 @@ void StartupTray(void)
 
    for(tp = trays; tp; tp = tp->next) {
 
+      if(tp->screenName) {
+         const int index = FindScreenByName(tp->screenName);
+         if(index >= 0) {
+            tp->screen = index;
+         } else {
+            Warning(_("tray screen \"%s\" not found"), tp->screenName);
+            tp->screen = 0;
+         }
+      }
       if(tp->screen >= GetScreenCount()) {
          Warning(_("tray screen index %d out of range"), tp->screen);
          tp->screen = 0;
@@ -210,6 +219,9 @@ void DestroyTray(void)
          Release(trays->components);
          trays->components = cp;
       }
+      if(trays->screenName) {
+         Release(trays->screenName);
+      }
       Release(trays);
 
       trays = tp;
@@ -226,6 +238,7 @@ TrayType *CreateTray(void)
    tp->requestedX = 0;
    tp->requestedY = -1;
    tp->screen = 0;
+   tp->screenName = NULL;
    tp->x = 0;
    tp->y = -1;
    tp->requestedWidth = 0;
@@ -1072,7 +1085,16 @@ void SetTrayHeight(TrayType *tp, const char *str)
 /** Set the tray screen index. */
 void SetTrayScreen(TrayType *tp, const char *str)
 {
-   tp->screen = atoi(str);
+   if(str[0] >= '0' && str[0] <= '9') {
+      tp->screen = atoi(str);
+   } else {
+      /* A screen name ("DP-2", "primary"); screens are not known at
+       * parse time, so resolution is deferred to StartupTray. */
+      if(tp->screenName) {
+         Release(tp->screenName);
+      }
+      tp->screenName = CopyString(str);
+   }
 }
 
 

--- a/src/tray.h
+++ b/src/tray.h
@@ -128,7 +128,7 @@ typedef struct TrayType {
    int requestedX;      /**< The user-requested x-coordinate of the tray. */
    int requestedY;      /**< The user-requested y-coordinate of the tray. */
 
-   int screen;       /**< The screen index (-1 if not known). */
+   int screen;       /**< The screen index (0 by default). */
    int x;            /**< The x-coordinate of the tray. */
    int y;            /**< The y-coordinate of the tray. */
 

--- a/src/tray.h
+++ b/src/tray.h
@@ -129,6 +129,8 @@ typedef struct TrayType {
    int requestedY;      /**< The user-requested y-coordinate of the tray. */
 
    int screen;       /**< The screen index (0 by default). */
+   char *screenName; /**< Requested screen by RandR output name
+                          (resolved to an index at startup). */
    int x;            /**< The x-coordinate of the tray. */
    int y;            /**< The y-coordinate of the tray. */
 


### PR DESCRIPTION
This adds native multi-monitor taskbar support, building on JWM's existing screen-bound tray placement (`<Tray screen="N">`). All new behavior is opt-in via jwmrc attributes, adds no new hard dependencies (XRandR is optional and
`--disable-xrandr`-able). Documented in `jwm.1.in`.

Features:

- `<TaskList screen="local"/>`: a task list shows only clients whose
  dominant (largest-overlap) Xinerama screen is the screen of its
  containing tray; `screen="all"` (default) is the previous behavior
  and a numeric value selects an explicit screen. With one tray per
  monitor this gives a per-monitor taskbar on each screen showing
  only that screen's windows.
- Task buttons follow windows across monitors: the dominant screen is
  cached on the client and re-evaluated on every configure, so a
  window dragged to another monitor migrates to that monitor's bar
  (appended at the end).
- `<TaskList rows="N"/>`: multi-row task buttons on horizontal trays
  (row-major layout; N=1, the default, renders exactly as before).
- `<Tray screen="DP-2">` / `<Tray screen="primary">`: with the new
  optional XRandR support, active CRTC rectangles are matched to the
  Xinerama screens by geometry at startup so trays can reference
  screens by output name; unknown names warn and fall back to
  screen 0. No RandR event handling is added; the configuration is
  re-read on restart as usual.
- Drag reordering of task buttons (left-drag; a plain click still
  activates/minimizes as before, now acted on button release). As
  part of this, DiscardButtonEvents no longer discards queued button
  releases, which could break press/release pairing for components
  with a release handler.

Tested under Xephyr multi-head and in daily use on a 4-monitor Ubuntu 24 desktop (including a rotated portrait monitor).